### PR TITLE
Correctness fixes for recursion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ setup.log
 
 # Local OPAM switch
 _opam/
+
+# ReasonML compilation creates node_modules
+node_modules/

--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,3 @@ setup.log
 
 # Local OPAM switch
 _opam/
-
-# ReasonML compilation creates node_modules
-node_modules/

--- a/lib/ast_grammar_normalized.re
+++ b/lib/ast_grammar_normalized.re
@@ -5,19 +5,20 @@ type ident = string;
 
 /* this is easier to translate into OCaml ADTs type definitions */
 
-[@deriving show]
+
+[@deriving show { with_path : false} ]
 type atom =
  | SYMBOL(ident)
  | TOKEN
  ;
 
-[@deriving show]
+[@deriving show { with_path : false} ]
 type simple =
  | ATOM(atom)
  | SEQ(list(atom)) /* codegen: (A,B,C,...) */
 ;
 
-[@deriving show]
+[@deriving show { with_path : false} ]
 type rule_body =
  | REPEAT(simple)       /* codegen: list(x) */
  | CHOICE(list(simple)) /* codegen: A(...) | B(...) */

--- a/lib/normalize_grammar.re
+++ b/lib/normalize_grammar.re
@@ -28,7 +28,7 @@ let rec normalize_to_simple = (body: A.rule_body): (B.simple, list(A.rule)) => {
 }
 and normalize_to_atom = (body: A.rule_body): (B.atom, list(A.rule)) => {
   switch (body) {
-  | A.TOKEN | A.STRING(_) | A.PATTERN(_) => (B.TOKEN, [])
+  | A.TOKEN |  A.IMMEDIATE_TOKEN | A.BLANK | A.STRING(_) | A.PATTERN(_) => (B.TOKEN, [])
   | A.SYMBOL(name) => (B.SYMBOL(name), [])
   /* Create intermediate symbol */
   | _ => {

--- a/lib/normalize_grammar.re
+++ b/lib/normalize_grammar.re
@@ -10,7 +10,18 @@ let gensym = () => {
 let rec normalize_to_simple = body => {
   switch (body) {
   | A.TOKEN => (B.ATOM(B.TOKEN), [])
-  | A.SYMBOL(name)=> (B.ATOM(B.SYMBOL(name)), [])
+  | A.SYMBOL(name) => (B.ATOM(B.SYMBOL(name)), [])
+  | A.SEQ(bodies) => {
+    let xs = List.map(normalize_to_atom, bodies);
+    let atoms = List.map(fst, xs);
+    let intermediates = List.flatten(List.map(snd, xs));
+    if (List.length(intermediates) == 0) {
+      (B.SEQ(atoms), [])
+    } else {
+      let fresh_ident = gensym();
+      (B.ATOM(B.SYMBOL(fresh_ident)), [(fresh_ident, body)]);
+    }
+  }
   /* Create intermediate symbol */
   | _ => {
     let fresh_ident = gensym();

--- a/lib/normalize_grammar.re
+++ b/lib/normalize_grammar.re
@@ -7,29 +7,38 @@ let gensym = () => {
   "intermediate" ++ string_of_int(counter^);
 }
 
-let rec normalize_to_atom = body => {
+let rec normalize_to_simple = body => {
+  switch (body) {
+  | A.TOKEN => (B.ATOM(B.TOKEN), [])
+  | A.SYMBOL(name)=> (B.ATOM(B.SYMBOL(name)), [])
+  /* Create intermediate symbol */
+  | _ => {
+    let fresh_ident = gensym();
+    (B.ATOM(B.SYMBOL(fresh_ident)), [(fresh_ident, body)]);
+    }
+  }
+}
+and normalize_to_atom = body => {
   switch (body) {
   | A.TOKEN => (B.TOKEN, [])
   | A.SYMBOL(name)=> (B.SYMBOL(name), [])
   /* Create intermediate symbol */
   | _ => {
     let fresh_ident = gensym();
-    (B.SYMBOL(fresh_ident), [(fresh_ident, fst(normalize_body(body)))]);
+    (B.SYMBOL(fresh_ident), [(fresh_ident, body)]);
     }
   }
 }
 and normalize_body = (rule_body) => {
   switch(rule_body) {
-  | A.TOKEN =>
-    (
-      B.SIMPLE(B.ATOM(B.TOKEN)),
-      []
-    );
-  | A.SYMBOL(name) =>
-    (
-      B.SIMPLE(B.ATOM(B.SYMBOL(name))),
-      []
-    );
+  | A.TOKEN => {
+      let (simple, rest) = normalize_to_simple(A.TOKEN);
+      (B.SIMPLE(simple), rest);
+    }
+  | A.SYMBOL(name) => {
+      let (simple, rest) = normalize_to_simple(A.SYMBOL(name));
+      (B.SIMPLE(simple), rest);
+    }
   | A.SEQ(bodies) => {
       let xs = List.map(normalize_to_atom, bodies);
       let atoms = List.map(fst, xs);
@@ -37,26 +46,38 @@ and normalize_body = (rule_body) => {
       (B.SIMPLE(B.SEQ(atoms)), intermediates)
     };
   | A.CHOICE(bodies) => {
-      let xs = List.map(normalize_to_atom, bodies);
-      let atoms = List.map(fst, xs);
-      let simples = List.map((atom) => B.ATOM(atom), atoms);
+      let xs = List.map(normalize_to_simple, bodies);
+      let simples = List.map(fst, xs);
       let intermediates = List.flatten(List.map(snd, xs));
       (B.CHOICE(simples), intermediates)
-  }
+    };
   | _ =>
     (
       B.SIMPLE(B.ATOM(B.TOKEN)),
       []
     );
-  }
+  };
 }
-
-let normalize_rule = ((name, rule_body)) => {
+and normalize_rule = ((name, rule_body)) => {
   let (this_body, intermediates) = normalize_body(rule_body);
-  let extra_rules = intermediates;
-  [(name, this_body), ...extra_rules]
+  let new_rules = ref([(name, this_body)]);
+  let s = Stack.create();
+  List.iter(item => Stack.push(item, s), intermediates);
+  while (!Stack.is_empty(s)) {
+    let (rname, body) = Stack.pop(s);
+    let (new_body, inters) = normalize_body(body);
+    new_rules := [(rname, new_body), ...new_rules^];
+    List.iter(item => Stack.push(item, s), inters);
+  };
+  [...new_rules^]
+}
+let normalize_rules = xs => List.stable_sort(
+  /* Sort rules by the name to guarantee deterministism */
+  (a,b) => String.compare(fst(a),fst(b)),
+  List.flatten(List.map(normalize_rule, xs)
+));
+
+let normalize = ((name: string, rules)) => {
+  counter := 0;
+  (name, normalize_rules(rules))
 };
-
-let normalize_rules = xs => List.flatten(List.map(normalize_rule, xs));
-
-let normalize = ((name: string, rules)) => (name, normalize_rules(rules));

--- a/lib/normalize_grammar.re
+++ b/lib/normalize_grammar.re
@@ -39,16 +39,10 @@ and normalize_to_atom = (body: A.rule_body): (B.atom, list(A.rule)) => {
 }
 and normalize_body = (rule_body: A.rule_body): (B.rule_body, list(A.rule)) => {
   switch(rule_body) {
-  | A.IMMEDIATE_TOKEN | A.BLANK | A.TOKEN | A.SYMBOL(_) | A.STRING(_) | A.PATTERN(_) => {
+  | A.IMMEDIATE_TOKEN | A.BLANK | A.TOKEN | A.SYMBOL(_) | A.STRING(_) | A.PATTERN(_) | A.SEQ(_) => {
       let (simple, rest) = normalize_to_simple(rule_body);
       (B.SIMPLE(simple), rest);
     }
-  | A.SEQ(bodies) => {
-      let xs = List.map(normalize_to_atom, bodies);
-      let atoms = List.map(fst, xs);
-      let intermediates = List.flatten(List.map(snd, xs));
-      (B.SIMPLE(B.SEQ(atoms)), intermediates)
-    };
   | A.CHOICE(bodies) => {
     switch (List.rev(bodies)) {
     | [A.BLANK] => failwith("Impossible, a single BLANK in a CHOICE")

--- a/lib/normalize_grammar.re
+++ b/lib/normalize_grammar.re
@@ -7,7 +7,7 @@ let gensym = () => {
   "intermediate" ++ string_of_int(counter^);
 }
 
-let rec normalize_to_simple = body => {
+let rec normalize_to_simple = (body: A.rule_body): (B.simple, list(A.rule)) => {
   switch (body) {
   | A.TOKEN => (B.ATOM(B.TOKEN), [])
   | A.SYMBOL(name) => (B.ATOM(B.SYMBOL(name)), [])
@@ -15,12 +15,7 @@ let rec normalize_to_simple = body => {
     let xs = List.map(normalize_to_atom, bodies);
     let atoms = List.map(fst, xs);
     let intermediates = List.flatten(List.map(snd, xs));
-    if (List.length(intermediates) == 0) {
-      (B.SEQ(atoms), [])
-    } else {
-      let fresh_ident = gensym();
-      (B.ATOM(B.SYMBOL(fresh_ident)), [(fresh_ident, body)]);
-    }
+    (B.SEQ(atoms), intermediates)
   }
   /* Create intermediate symbol */
   | _ => {
@@ -29,7 +24,7 @@ let rec normalize_to_simple = body => {
     }
   }
 }
-and normalize_to_atom = body => {
+and normalize_to_atom = (body: A.rule_body): (B.atom, list(A.rule)) => {
   switch (body) {
   | A.TOKEN => (B.TOKEN, [])
   | A.SYMBOL(name)=> (B.SYMBOL(name), [])
@@ -40,55 +35,38 @@ and normalize_to_atom = body => {
     }
   }
 }
-and normalize_body = (rule_body) => {
+and normalize_body = (rule_body: A.rule_body): (B.rule_body, list(A.rule)) => {
   switch(rule_body) {
-  | A.TOKEN => {
-      let (simple, rest) = normalize_to_simple(A.TOKEN);
+  | A.TOKEN | A.SYMBOL(_) | A.SEQ(_) => {
+      let (simple, rest) = normalize_to_simple(rule_body);
       (B.SIMPLE(simple), rest);
     }
-  | A.SYMBOL(name) => {
-      let (simple, rest) = normalize_to_simple(A.SYMBOL(name));
-      (B.SIMPLE(simple), rest);
-    }
-  | A.SEQ(bodies) => {
-      let xs = List.map(normalize_to_atom, bodies);
-      let atoms = List.map(fst, xs);
-      let intermediates = List.flatten(List.map(snd, xs));
-      (B.SIMPLE(B.SEQ(atoms)), intermediates)
-    };
   | A.CHOICE(bodies) => {
       let xs = List.map(normalize_to_simple, bodies);
       let simples = List.map(fst, xs);
       let intermediates = List.flatten(List.map(snd, xs));
       (B.CHOICE(simples), intermediates)
     };
-  | _ =>
-    (
-      B.SIMPLE(B.ATOM(B.TOKEN)),
-      []
-    );
+  | _ => failwith("TODO");
   };
 }
-and normalize_rule = ((name, rule_body)) => {
+and normalize_rule = ((name, rule_body): A.rule): (list(B.rule)) => {
   let (this_body, intermediates) = normalize_body(rule_body);
-  let new_rules = ref([(name, this_body)]);
-  let s = Stack.create();
-  List.iter(item => Stack.push(item, s), intermediates);
-  while (!Stack.is_empty(s)) {
-    let (rname, body) = Stack.pop(s);
-    let (new_body, inters) = normalize_body(body);
-    new_rules := [(rname, new_body), ...new_rules^];
-    List.iter(item => Stack.push(item, s), inters);
-  };
-  [...new_rules^]
+  let this_rule = (name, this_body);
+  if (intermediates == []) {
+    [this_rule]
+  } else {
+    let other_rules = List.flatten(List.map(normalize_rule, intermediates));
+    [this_rule, ...other_rules]
+  }
 }
-let normalize_rules = xs => List.stable_sort(
+let normalize_rules = (xs: list(A.rule)): (list(B.rule)) => List.stable_sort(
   /* Sort rules by the name to guarantee deterministism */
   (a,b) => String.compare(fst(a),fst(b)),
   List.flatten(List.map(normalize_rule, xs)
 ));
 
-let normalize = ((name: string, rules)) => {
+let normalize = ((name, rules): A.grammar): (B.grammar) => {
   counter := 0;
   (name, normalize_rules(rules))
 };

--- a/lib/normalize_grammar.rei
+++ b/lib/normalize_grammar.rei
@@ -1,1 +1,29 @@
-let normalize: Ast_grammar.t => Ast_grammar_normalized.t;
+
+module A = Ast_grammar;
+module B = Ast_grammar_normalized;
+
+let normalize_to_simple: A.rule_body => (
+  B.simple,
+  list((string, A.rule_body))
+)
+
+let normalize_to_atom: A.rule_body => (
+  B.atom,
+  list((string, A.rule_body))
+)
+
+let normalize_body: A.rule_body => (
+  B.rule_body,
+  list((string, A.rule_body))
+)
+
+
+let normalize_rule: ((string, A.rule_body)) => list(
+  (string, B.rule_body)
+)
+
+let normalize_rules: list((string, A.rule_body)) => list(
+  (string, B.rule_body)
+)
+
+let normalize: A.t => B.t;

--- a/lib/test_tree_sitter.re
+++ b/lib/test_tree_sitter.re
@@ -42,6 +42,71 @@ let _test_normalization = (ex1, expected_1) => {
     print_string(B.show_grammar(ex1_normalized) ++ "\n");
   }
 }
+let test_normalization_3 = _ => {
+  /*
+             CHOICE
+              / |
+        CHOICE TOKEN
+        /  \
+    CHOICE TOKEN
+      /  \
+  CHOICE  TOKEN
+    |
+  TOKEN
+  */
+  let grammar = (
+    "ex3_grammar",
+    [(
+      "ex3_rule",
+      A.CHOICE([
+        A.CHOICE([
+          A.CHOICE([
+            A.CHOICE([
+              A.TOKEN
+            ]),
+            A.TOKEN,
+          ]),
+          A.TOKEN
+        ]),
+        A.TOKEN,
+      ])
+    )]
+  );
+  let expected = (
+    "ex3_grammar",
+    [
+      (
+        "ex3_rule",
+        B.CHOICE([
+          B.ATOM(B.SYMBOL("intermediate1")),
+          B.ATOM(B.TOKEN),
+        ])
+      ),
+      (
+        "intermediate1",
+        B.CHOICE([
+          B.ATOM(B.SYMBOL("intermediate2")),
+          B.ATOM(B.TOKEN),
+        ])
+      ),
+      (
+        "intermediate2",
+        B.CHOICE([
+          B.ATOM(B.SYMBOL("intermediate3")),
+          B.ATOM(B.TOKEN),
+        ])
+      ),
+      (
+        "intermediate3",
+        B.CHOICE([
+          B.ATOM(B.TOKEN),
+        ])
+      ),
+    ]
+  );
+  _test_normalization(grammar, expected);
+
+}
 
 let test_normalization_2 = _ => {
   /*
@@ -68,13 +133,13 @@ let test_normalization_2 = _ => {
       (
         "ex2_rule",
         B.SIMPLE(B.SEQ([
-          B.SYMBOL("intermediate2"),
+          B.SYMBOL("intermediate1"),
           B.TOKEN,
           B.SYMBOL("A")
         ]))
       ),
       (
-        "intermediate2",
+        "intermediate1",
         B.CHOICE([
           B.ATOM(B.SYMBOL("B")),
           B.ATOM(B.TOKEN),
@@ -127,6 +192,7 @@ let test_normalization_1 = _ => {
 let test_normalization = _ => {
   test_normalization_1();
   test_normalization_2();
+  test_normalization_3();
 }
 
 let test_codegen_types = file => {

--- a/lib/test_tree_sitter.re
+++ b/lib/test_tree_sitter.re
@@ -42,6 +42,54 @@ let _test_normalization = (ex1, expected_1) => {
     print_string(B.show_grammar(ex1_normalized) ++ "\n");
   }
 }
+
+let test_normalization_4 = _ => {
+  /*
+               CHOICE
+              / |   \   \
+        SEQ  SYMBOL(A) SYMBOL(B) SEQ
+        /\                       /\
+    SYMBOL(C) SYMBOL(D)   SYMBOL(E) SYMBOL(F)
+  */
+  let grammar = (
+    "ex4",
+    [(
+      "arith_expression",
+      A.CHOICE([
+        A.SEQ([
+          A.SYMBOL("C"),
+          A.SYMBOL("D"),
+        ]),
+        A.SYMBOL("A"),
+        A.SYMBOL("B"),
+        A.SEQ([
+          A.SYMBOL("E"),
+          A.SYMBOL("F"),
+        ])
+      ])
+    )]
+  );
+  let expected = (
+    "ex4",
+    [(
+      "arith_expression",
+      B.CHOICE([
+        B.SEQ([
+          B.SYMBOL("C"),
+          B.SYMBOL("D")
+        ]),
+        B.ATOM(B.SYMBOL("A")),
+        B.ATOM(B.SYMBOL("B")),
+        B.SEQ([
+          B.SYMBOL("E"),
+          B.SYMBOL("F")
+        ])
+      ])
+    )]
+  );
+  _test_normalization(grammar, expected);
+}
+
 let test_normalization_3 = _ => {
   /*
              CHOICE
@@ -193,6 +241,7 @@ let test_normalization = _ => {
   test_normalization_1();
   test_normalization_2();
   test_normalization_3();
+  test_normalization_4();
 }
 
 let test_codegen_types = file => {


### PR DESCRIPTION
Addressing the main drawback from https://github.com/returntocorp/ocaml-tree-sitter/pull/4, namely, 
- `normalize_to_simple`
- `normalize_to_atom`
- `normalize_body`

now returns the A.rule_body for the intermediates so that `normalize_rule` can exhaustively call `normalize_body` on intermediates until there is no more intermediates.
(Additionally, now resets the intermediate counter for each invocation of `normalize`) 

Added a test for:
```
             CHOICE
              / |
        CHOICE TOKEN
        /  \
    CHOICE TOKEN
      /  \
  CHOICE  TOKEN
    |
  TOKEN
```