### PR TITLE
Script to scan public projects + better input dumper

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 /bin
+tmp
 
 # Dune build data
 /_build

--- a/lang/ruby/Makefile
+++ b/lang/ruby/Makefile
@@ -52,6 +52,10 @@ parse-step1:
 parse-step2:
 	$(SCRIPTS)/parse-step2
 
+.PHONY: stat
+stat:
+	$(SCRIPTS)/lang-stat projects.txt extensions.txt
+
 .PHONY: clean
 clean:
 	git clean -dfX

--- a/lang/ruby/extensions.txt
+++ b/lang/ruby/extensions.txt
@@ -1,0 +1,2 @@
+# File extensions for the Ruby language
+.rb

--- a/lang/ruby/projects.txt
+++ b/lang/ruby/projects.txt
@@ -1,0 +1,54 @@
+#
+# Popular Ruby projects
+#
+git@github.com:helpyio/helpy.git
+git@github.com:rubygems/rubygems.org.git
+git@github.com:huginn/huginn.git
+
+# Ruby parts of Travis CI
+git@github.com:travis-ci/travis-build.git
+git@github.com:travis-ci/travis-api.git
+git@github.com:travis-ci/travis-cookbooks.git
+git@github.com:travis-ci/travis-hub.git
+git@github.com:travis-ci/travis-listener.git
+git@github.com:travis-ci/travis-logs.git
+git@github.com:travis-ci/travis-support.git
+git@github.com:travis-ci/travis-tasks.git
+
+git@github.com:OWASP/railsgoat.git
+
+# Most starred on GitHub:
+#   https://github.com/topics/ruby?l=ruby&o=desc&s=stars
+#
+# These were gathered by hand. Maybe next time we can automate this.
+#
+git@github.com:rails/rails.git
+git@github.com:jekyll/jekyll.git
+git@github.com:discourse/discourse.git
+git@github.com:fastlane/fastlane.git
+git@github.com:gitlabhq/gitlabhq.git
+git@github.com:Homebrew/brew.git
+git@github.com:heartcombo/devise.git
+git@github.com:hashicorp/vagrant.git
+git@github.com:ruby/ruby.git
+git@github.com:diaspora/diaspora.git
+git@github.com:capistrano/capistrano.git
+git@github.com:sinatra/sinatra.git
+git@github.com:rubocop-hq/rubocop.git
+git@github.com:spree/spree.git
+git@github.com:mperham/sidekiq.git
+git@github.com:postalhq/postal.git
+git@github.com:fluent/fluentd.git
+git@github.com:ruby-grape/grape.git
+git@github.com:activeadmin/activeadmin.git
+git@github.com:faker-ruby/faker.git
+git@github.com:kaminari/kaminari.git
+git@github.com:heartcombo/simple_form.git
+git@github.com:Homebrew/homebrew-core.git
+git@github.com:thoughtbot/factory_bot.git
+git@github.com:lewagon/setup.git
+git@github.com:realm/jazzy.git
+git@github.com:chef/chef.git
+git@github.com:puma/puma.git
+git@github.com:pry/pry.git
+git@github.com:github-changelog-generator/github-changelog-generator.git

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -1,0 +1,101 @@
+#! /usr/bin/env bash
+#
+# Fetch git projects from a list and run our parser on the files for
+# a language of interest.
+#
+set -eu -o pipefail
+
+progname=$(basename "$0")
+
+usage() {
+  cat <<EOF
+Usage: $progname PROJECTS_FILE EXTENSIONS_FILE
+
+For each project specified by a git URL in PROJECTS_FILE, run the local
+parser on all the files of the project whose extension matches one of the
+extensions in EXTENSIONS_FILE.
+
+Example: $progname projects.txt extensions.txt
+EOF
+}
+
+error() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
+[[ "${BASH_VERSION%%.*}" -ge 4 ]] || error "requires bash >= 4"
+
+if [[ $# != 2 ]]; then
+  usage 2>&1
+  exit 1
+fi
+
+projects_file="$1"
+extensions_file="$2"
+
+# Read lines into array after removing comments and blank lines.
+readarray -t urls < <(grep -v '^ *\(#\| *$\)' "$projects_file")
+readarray -t extensions < <(grep -v '^ *\(#\| *$\)' "$extensions_file")
+
+csv=stat.csv
+
+# CSV header
+cat > "$csv" <<EOF
+"Project URL","Parse attempts","Parse failures","Lines of code"
+EOF
+
+tree_sitter_parser=$(pwd)/tree-sitter-parser.js
+ocaml_parser=$(pwd)/ocaml-src/_build/install/default/bin/parse
+
+parse() {
+  (
+    cd tmp
+    json=out.json
+    ast=out.ast
+    "$tree_sitter_parser" "$input" | ydump > "$json"
+    "$ocaml_parser" "$input" "$json" > /dev/null
+  ) > tmp/parse.log 2>&1
+}
+
+handle_project() {
+  echo "Fetch $url."
+  (
+    cd tmp
+    rm -rf repo
+    rm -f inputs
+    git clone --depth 1 "$url" repo
+    for ext in "${extensions[@]}"; do
+      if [[ -n "$ext" ]]; then
+        find repo -name "*$ext" >> inputs
+      fi
+    done
+  )
+  readarray -t inputs < <(cat tmp/inputs)
+  num_files=${#inputs[@]}
+  echo "Found $num_files files."
+  errors=0
+  line_count=0
+  for input in "${inputs[@]}"; do
+    echo -n "$input"
+    file_line_count=$(wc -l "tmp/$input" | cut -f1 -d' ')
+    echo -n " ($file_line_count lines)"
+    line_count=$(( line_count + file_line_count ))
+    if parse; then
+      echo "  OK"
+    else
+      errors=$(( errors + 1 ))
+      echo "  ERROR"
+    fi
+  done
+  echo "$url,$num_files,$errors,$line_count" >> "$csv"
+}
+
+mkdir -p tmp
+for url in "${urls[@]}"; do
+  (
+    handle_project || "Failed on $url"
+  ) 2>&1 | tee tmp/lang-stat.log
+done
+
+echo "Result file: $csv"

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -94,7 +94,7 @@ handle_project() {
 mkdir -p tmp
 for url in "${urls[@]}"; do
   (
-    handle_project || "Failed on $url"
+    handle_project || echo "Failed on $url"
   ) 2>&1 | tee tmp/lang-stat.log
 done
 

--- a/src/gen/lib/Codegen_parse.ml
+++ b/src/gen/lib/Codegen_parse.ml
@@ -71,6 +71,8 @@ let gen_extras grammar =
 let preamble ~ast_module_name grammar =
   [
     Line constant_header;
+    Line (sprintf "let debug = %B" debug_run);
+    Line "";
     Inline (gen_extras grammar);
     Line (sprintf "\
 let parse ~src_file ~json_file : %s.%s option =
@@ -82,6 +84,9 @@ let parse ~src_file ~json_file : %s.%s option =
       json_file
     |> Combine.assign_unique_ids
   in
+
+  if debug then
+    Tree_sitter_dump.to_stdout [root_node];
 
   let get_token x =
     Src_file.get_token src x.startPosition x.endPosition in

--- a/src/run/lib/Tree_sitter_dump.ml
+++ b/src/run/lib/Tree_sitter_dump.ml
@@ -1,0 +1,30 @@
+(*
+   Compact pretty-printing of the tree-sitter output.
+*)
+
+open Printf
+open Tree_sitter_output_t
+
+let extend_indent s =
+  if String.length s mod 4 = 0 then
+    s ^ "| "
+  else
+    s ^ "  "
+
+let to_buf buf nodes =
+  let rec print indent nodes =
+    List.iter (print_node indent) nodes
+  and print_node indent node =
+    bprintf buf "%s%s\n" indent node.type_;
+    print (extend_indent indent) node.children
+  in
+  print "" nodes
+
+let to_string nodes =
+  let buf = Buffer.create 1000 in
+  to_buf buf nodes;
+  Buffer.contents buf
+
+let to_stdout nodes =
+  print_string (to_string nodes);
+  flush stdout


### PR DESCRIPTION
This branch adds 2 things:

* From `lang/ruby`, `make stat` starts the work of fetching git projects and running our parser on it, producing a csv file. Current parsing success rate is around 50%. The code should work on other languages than Ruby (just change the `projects.txt` and `extensions.txt` files).
* Input from tree-sitter is dumped in a more readable format than the original json. Looks like this for this `arithmetic` example `ex1`:

```
program              
| expression_statement
|   expression
|   | number
|   ;
| expression_statement
|   expression
|   | expression
|   |   number
|   | +
|   | expression
|   |   number
|   ;
| expression_statement
|   expression
|   | expression
|   |   number
|   | -
|   | expression
|   |   number
|   ;
| expression_statement
|   expression
|   | expression
|   |   number
|   | *
|   | expression
|   |   number
|   ;
| expression_statement
|   expression
|   | expression
|   |   number
|   | /
|   | expression
|   |   number
|   ;
| expression_statement
|   expression
|   | expression
|   |   number
|   | ^
|   | expression
|   |   number
|   ;
```
(vertical bars have no semantic value, they're only for readability; it's more obvious when working on typical, deeply nested programs)
