### PR TITLE
Add Dockerfile + CircleCI config

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,32 @@
+#
+# Circle CI configuration. Runs each time we push a new commit to Github.
+#
+# This file is derived from the project's Dockerfile, which we use for
+# local testing.
+#
+version: 2.1
+jobs:
+  build:
+    docker:
+      - image: ocaml/opam2:debian-stable
+    working_directory: ~/ocaml-tree-sitter
+    steps:
+      - checkout
+      - run:
+          name: set up node
+          command: ./scripts/setup-node
+      - run:
+          name: set up opam
+          command: ./scripts/setup-opam
+      - run:
+          name: install dependencies
+          command: opam exec -- make setup
+      - run:
+          name: build
+          command: opam exec -- make
+      - run:
+          name: install
+          command: opam exec -- make install
+      - run:
+          name: test
+          command: opam exec -- make test

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,13 @@
+#
+# Translated manually from .gitignore.
+#
+
+bin
+**/tmp
+**/_build
+**/.merlin
+**/*.install
+_opam
+node_modules
+package-lock.json
+tree-sitter

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,39 @@
+#
+# Reference workflow for building and testing ocaml-tree-sitter.
+#
+# Run with:
+#
+#   docker build -t ocaml-tree-sitter .
+#
+# Enter the resulting container with:
+#
+#   docker run -it ocaml-tree-sitter
+#
+
+FROM ocaml/opam2:debian-stable
+
+COPY --chown=opam:opam scripts /home/opam/ocaml-tree-sitter/scripts
+COPY --chown=opam:opam Makefile /home/opam/ocaml-tree-sitter/Makefile
+WORKDIR /home/opam/ocaml-tree-sitter
+RUN sudo chown opam:opam .
+
+# Slow steps that mostly download and build external stuff.
+RUN ./scripts/setup-node
+RUN ./scripts/setup-opam
+COPY --chown=opam:opam tree-sitter.opam /home/opam/ocaml-tree-sitter/tree-sitter.opam
+RUN opam exec -- make setup
+
+# Copy the rest, which changes often.
+COPY --chown=opam:opam . /home/opam/ocaml-tree-sitter
+
+# 'opam exec -- CMD' sets environment variables (PATH etc.) and runs
+# command CMD in this environment.
+# This is equivalent to 'eval $(opam env)' which normally goes into
+# ~/.bashrc or similar.
+#
+RUN opam exec -- make
+RUN opam exec -- make install
+
+# FIXME Why does ld not search /usr/local/lib despite it being listed
+# in /etc/ld.so.conf.d/libc.conf ?
+RUN LD_LIBRARY_PATH=/usr/local/lib opam exec -- make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,4 @@ COPY --chown=opam:opam . /home/opam/ocaml-tree-sitter
 #
 RUN opam exec -- make
 RUN opam exec -- make install
-
-# FIXME Why does ld not search /usr/local/lib despite it being listed
-# in /etc/ld.so.conf.d/libc.conf ?
-RUN LD_LIBRARY_PATH=/usr/local/lib opam exec -- make test
+RUN opam exec -- make test

--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ FROM ocaml/opam2:debian-stable
 COPY --chown=opam:opam scripts /home/opam/ocaml-tree-sitter/scripts
 COPY --chown=opam:opam Makefile /home/opam/ocaml-tree-sitter/Makefile
 WORKDIR /home/opam/ocaml-tree-sitter
+
+# hadolint ignore=DL3004 https://github.com/hadolint/hadolint/wiki/DL3004
 RUN sudo chown opam:opam .
 
 # Slow steps that mostly download and build external stuff.

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ COPY --chown=opam:opam scripts /home/opam/ocaml-tree-sitter/scripts
 COPY --chown=opam:opam Makefile /home/opam/ocaml-tree-sitter/Makefile
 WORKDIR /home/opam/ocaml-tree-sitter
 
-# hadolint ignore=DL3004 https://github.com/hadolint/hadolint/wiki/DL3004
+# hadolint ignore=DL3004
 RUN sudo chown opam:opam .
 
 # Slow steps that mostly download and build external stuff.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ocaml-tree-sitter
 
+[![CircleCI](https://circleci.com/gh/returntocorp/ocaml-tree-sitter.svg?style=svg)](https://circleci.com/gh/returntocorp/ocaml-tree-sitter)
+
 Generate OCaml parsers based on
 [tree-sitter](https://tree-sitter.github.io/tree-sitter/) grammars.
 

--- a/scripts/install-tree-sitter-cli
+++ b/scripts/install-tree-sitter-cli
@@ -5,14 +5,8 @@
 #
 set -eu
 
-project_root=$(git rev-parse --show-toplevel)
-
-# Install node modules at the project root.
+# Install node modules. Should be done at the project root.
 # The tree-sitter executable will be in 'node_modules/.bin'.
-(
-  cd "$project_root"
-
-  npm install \
+npm install \
     tree-sitter \
     tree-sitter-cli
-)

--- a/scripts/install-tree-sitter-lib
+++ b/scripts/install-tree-sitter-lib
@@ -4,8 +4,6 @@
 #
 set -eu
 
-project_root=$(git rev-parse --show-toplevel)
-
 if [[ ! -e tree-sitter ]]; then
   git clone --depth 1 https://github.com/tree-sitter/tree-sitter.git
 fi

--- a/scripts/install-tree-sitter-lib
+++ b/scripts/install-tree-sitter-lib
@@ -14,4 +14,5 @@ fi
   git clean -dfX
   make
   sudo make install
+  sudo ldconfig /usr/local/lib
 )

--- a/scripts/setup-node
+++ b/scripts/setup-node
@@ -1,0 +1,23 @@
+#! /usr/bin/env bash
+#
+# Install Node.js so that we can install the tree-sitter command-line
+# interface. Intended for Debian/Ubuntu only.
+#
+
+cat > ~/.npmrc <<EOF
+prefix = ~/.node
+EOF
+
+cat >> ~/.bashrc <<EOF
+export PATH="$HOME/.node/bin:$PATH"
+export NODE_PATH="$HOME/.node/lib/node_modules:$NODE_PATH"
+export MANPATH="$HOME/.node/share/man:$MANPATH"
+EOF
+
+sudo apt-get update
+sudo apt-get install -y nodejs npm
+
+npm install npm -g
+
+# Local install into node_modules/
+npm install node-gyp

--- a/scripts/setup-opam
+++ b/scripts/setup-opam
@@ -7,7 +7,7 @@
 sudo apt-get update
 sudo apt-get install -y m4
 
-opam switch 4.09
+opam switch 4.10
 
 if ! (opam repo list | grep -q http); then
   opam repo add --all -k git github \

--- a/scripts/setup-opam
+++ b/scripts/setup-opam
@@ -1,0 +1,17 @@
+#! /usr/bin/env bash
+#
+# Complete the opam setup already in place in the docker image
+# ocaml/opam2:debian-stable.
+#
+
+sudo apt-get update
+sudo apt-get install -y m4
+
+opam switch 4.09
+
+if ! (opam repo list | grep -q http); then
+  opam repo add --all -k git github \
+       https://github.com/ocaml/opam-repository.git
+fi
+
+opam update

--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -18,6 +18,7 @@ depends: [
   "ocaml"
   "ppx_deriving"
   "ppx_sexp_conv"
+  "sexplib"
   "tsort" {>= "2.0"}
 ]
 

--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -17,6 +17,7 @@ depends: [
   "dune" {>= "2.1"}
   "ocaml"
   "ppx_deriving"
+  "ppx_sexp_conv"
   "tsort" {>= "2.0"}
 ]
 


### PR DESCRIPTION
The build uses ocaml 4.10.

* `Dockerfile` works. It serves as a reference and allows local testing.
* The CircleCI setup is a translation of the dockerfile.

CircleCI worked twice and failed once, despite no significant changes. I think we can merge this but there's something fishy that will need to be fixed. See https://app.circleci.com/pipelines/github/returntocorp/ocaml-tree-sitter?branch=ci

The CircleCI run takes between 6 and 10 minutes.