### PR TITLE
Fix warning triggered by -Wgnu-designator in generated bindings.c

### DIFF
--- a/scripts/gen-ocaml
+++ b/scripts/gen-ocaml
@@ -161,12 +161,12 @@ void finalize_parser(value v) {
 }
 
 static struct custom_operations parser_custom_ops = {
-  identifier : "parser handling",
-  finalize : finalize_parser,
-  compare : custom_compare_default,
-  hash : custom_hash_default,
-  serialize : custom_serialize_default,
-  deserialize : custom_deserialize_default
+  .identifier = "parser handling",
+  .finalize = finalize_parser,
+  .compare = custom_compare_default,
+  .hash = custom_hash_default,
+  .serialize = custom_serialize_default,
+  .deserialize = custom_deserialize_default
 };
 
 // OCaml function


### PR DESCRIPTION
Uses C99 style for initializing struct with named fields instead of old GNU style, getting rid of
```
warning: use of GNU old-style field designator extension [-Wgnu-designator]
```
