### PR TITLE
Prevent name conflicts of local functions of the 'bindings.c' files.

### DIFF
--- a/scripts/gen-ocaml
+++ b/scripts/gen-ocaml
@@ -166,7 +166,7 @@ typedef struct _parser {
   TSParser *parser;
 } parser_W;
 
-void finalize_parser(value v) {
+static void finalize_parser(value v) {
   parser_W *p;
   p = (parser_W *)Data_custom_val(v);
   ts_parser_delete(p->parser);

--- a/src/bindings/lib/bindings.c
+++ b/src/bindings/lib/bindings.c
@@ -39,7 +39,7 @@ typedef struct _tree {
   TSTree *tree;
 } tree_W;
 
-void finalize_tree(value v) {
+static void finalize_tree(value v) {
   tree_W *p;
   p = (tree_W *)Data_custom_val(v);
   //TODO: ts_tree_delete(p->tree);


### PR DESCRIPTION
Fixes https://github.com/returntocorp/ocaml-tree-sitter/issues/68