### PR TITLE
inline/deinline

### DIFF
--- a/src/gen/lib/CST_grammar_conv.ml
+++ b/src/gen/lib/CST_grammar_conv.ml
@@ -96,7 +96,7 @@ let translate ~rule_name (x : Tree_sitter_t.rule_body) =
 
   and translate_choice opt_rule_name cases =
     let translated_cases = List.map translate cases in
-    Type_name.assign_case_names opt_rule_name translated_cases
+    Type_name.assign_case_names ?rule_name:opt_rule_name translated_cases
   in
   translate ~rule_name x
 

--- a/src/gen/lib/CST_grammar_conv.mli
+++ b/src/gen/lib/CST_grammar_conv.mli
@@ -21,6 +21,7 @@
 val of_tree_sitter : Tree_sitter_t.grammar -> CST_grammar.t
 
 (* Sort and group the rules based on interdependencies. This is already
-   done as part of 'of_tree_sitter'. *)
+   done as part of 'of_tree_sitter'.
+*)
 val tsort_rules :
-  (string * CST_grammar.rule_body) list -> CST_grammar.rule list list
+  CST_grammar.rule list -> CST_grammar.rule list list

--- a/src/gen/lib/Codegen_CST.ml
+++ b/src/gen/lib/Codegen_CST.ml
@@ -213,7 +213,9 @@ and format_seq l =
   List.map format_body l
 
 let format_rule (rule : rule) =
-  (trans rule.name, rule.is_inlined, format_body ~def_name:rule.name rule.body)
+  (trans rule.name,
+   rule.is_inlined_type,
+   format_body ~def_name:rule.name rule.body)
 
 let ppx =
   Fmt.top_sequence [

--- a/src/gen/lib/Codegen_boilerplate.ml
+++ b/src/gen/lib/Codegen_boilerplate.ml
@@ -162,7 +162,7 @@ let gen ~cst_module_name grammar =
     in
     let bindings =
       List.filter_map (fun rule ->
-        if rule.is_inlined then
+        if rule.is_inlined_type then
           None
         else
           Some (gen_rule_mapper_binding ~cst_module_name rule)

--- a/src/gen/lib/Codegen_parse.ml
+++ b/src/gen/lib/Codegen_parse.ml
@@ -403,7 +403,19 @@ let file src_file =
 |}
     (trans grammar.entrypoint)
 
+(*
+   Generate a parsing function for each rule in the tree-sitter grammar
+   ('grammar.json' file).
+*)
 let generate ~cst_module_name grammar =
+  let grammar =
+    let rules =
+      List.map (
+        List.filter (fun rule -> not rule.is_inlined_rule)
+      ) grammar.rules
+    in
+    { grammar with rules }
+  in
   let tree = gen ~cst_module_name grammar in
   let ml_contents = Indent.to_string [
     Inline (preamble grammar);

--- a/src/gen/lib/Deinline.ml
+++ b/src/gen/lib/Deinline.ml
@@ -1,0 +1,34 @@
+(*
+   Undo the duplications introduced by the 'inline' field of the grammar
+   so as to recover the original names of anonymous nodes.
+
+   This inlining must occur in the grammar so as to avoid parsing conflicts.
+   It is not just "useful for rules that are used in multiple places but
+   for which you don’t want to create syntax tree nodes at runtime" as stated
+   in the tree-sitter manual (2020-07-24).
+
+   However, there seems to be an equivalence between a rule name that starts
+   with an underscore ('_inline_me') and any rule name listed in the
+   'inline' section of the grammar, with or without an underscore.
+   In both cases, '_inline_me: ...' and 'rules: $ => [ $.inline_me ]' yield
+   a CST that lacks a node with that name.
+
+   Since we don't support hidden rules to simplify our parsing ('Parse.ml'),
+   our 'grammar.json' is always pre-processed to prevent hidden/inlined
+   rules. Our solution is to perform the inlining ourselves, resulting
+   in duplicated grammar nodes. See 'Simplify_grammar.ml'.
+
+   Here we are concerned with recovering the original names of the
+   grammar nodes that we inlined in 'grammar.json'. The named rules
+   that were inlined were left in the grammar even though they're
+   unreachable from the grammar's entry point. This allows us to
+   deinline them, i.e. recover the structure of the original grammar
+   before inlining.
+*)
+
+let deinline_rules grammar =
+  Factorize.factorize_rules
+    ~create_names:false
+    ~min_uses:0
+    ~min_size:0
+    grammar

--- a/src/gen/lib/Deinline.ml
+++ b/src/gen/lib/Deinline.ml
@@ -7,16 +7,17 @@
    for which you don’t want to create syntax tree nodes at runtime" as stated
    in the tree-sitter manual (2020-07-24).
 
-   However, there seems to be an equivalence between a rule name that starts
-   with an underscore ('_inline_me') and any rule name listed in the
-   'inline' section of the grammar, with or without an underscore.
-   In both cases, '_inline_me: ...' and 'rules: $ => [ $.inline_me ]' yield
-   a CST that lacks a node with that name.
+   It seems that any rule name listed in the 'rules' section is automatically
+   considered hidden, even if it doesn't start with an underscore:
 
-   Since we don't support hidden rules to simplify our parsing ('Parse.ml'),
-   our 'grammar.json' is always pre-processed to prevent hidden/inlined
-   rules. Our solution is to perform the inlining ourselves, resulting
-   in duplicated grammar nodes. See 'Simplify_grammar.ml'.
+     inline => hidden
+
+   but not the reverse.
+
+   Since we don't support hidden rules so as to simplify our parsing
+   ('Parse.ml'), our 'grammar.json' is always pre-processed to prevent
+   hidden/inlined rules. Our solution is to apply the inlining ourselves,
+   resulting in duplicated grammar nodes. See 'Simplify_grammar.ml'.
 
    Here we are concerned with recovering the original names of the
    grammar nodes that we inlined in 'grammar.json'. The named rules

--- a/src/gen/lib/Factorize.ml
+++ b/src/gen/lib/Factorize.ml
@@ -165,9 +165,20 @@ let factorize_rules
   let all_rules =
     Hashtbl.fold (fun name node acc -> (name, node) :: acc) new_rules []
   in
+  let get_orig_rule = CST_grammar.make_rule_lookup grammar in
   let rules =
     List.map (fun (name, orig_node) ->
-      (name, replace_nodes node_names orig_node)
+      let is_inlined_rule, is_inlined_type =
+        match get_orig_rule name with
+        | None -> false, false
+        | Some x -> x.is_inlined_rule, x.is_inlined_type
+      in
+      let body = replace_nodes node_names orig_node in
+      { name;
+        body;
+        is_rec = true; (* will be set correctly by tsort below *)
+        is_inlined_rule;
+        is_inlined_type }
     ) all_rules
     |> CST_grammar_conv.tsort_rules
   in

--- a/src/gen/lib/Factorize.mli
+++ b/src/gen/lib/Factorize.mli
@@ -1,5 +1,26 @@
 (*
-   As part of the simplify-grammar program, identify duplicated anonymous
-   rules and give them a name.
+   Identify duplicated anonymous rules and give them a name.
 *)
-val factorize_rules : ?min_size:int -> CST_grammar.t -> CST_grammar.t
+
+(*
+   Identify grammar nodes that are duplicated or exist as a named rule
+   and share a name.
+
+   The default parameters are for detecting duplicates of sufficient size,
+   resulting in the creation of named nodes used multiple times:
+   - create_names = true
+   - min_uses = 2
+   - min_size = 3
+
+   This function can also be used to identify nodes that are the result
+   of inlining, and replacing them by their original name. The settings
+   for this would be:
+   - create_names = false
+   - min_uses = 0
+   - min_size = 0
+*)
+val factorize_rules :
+  ?create_names:bool ->
+  ?min_uses:int ->
+  ?min_size:int ->
+  CST_grammar.t -> CST_grammar.t

--- a/src/gen/lib/Inline.ml
+++ b/src/gen/lib/Inline.ml
@@ -201,7 +201,7 @@ let inline_rules grammar =
           List.filter_map
             (fun (rule : rule) ->
                if get_definitive_times_used rule.name = 0 then (
-                 unused := [{rule with is_inlined = true}] :: !unused;
+                 unused := [{rule with is_inlined_type = true}] :: !unused;
                  None
                )
                else

--- a/src/gen/lib/Nice_typedefs.ml
+++ b/src/gen/lib/Nice_typedefs.ml
@@ -4,8 +4,8 @@
 
    1. Undo the inlining of grammar rules due to the 'inline' field
       of the grammar.
-   3. Factor out and assign a name to large nodes that occur multiple times.
-   4. Inline small definitions that are used only once.
+   2. Factor out and assign a name to large nodes that occur multiple times.
+   3. Inline small definitions that are used only once.
 *)
 
 let rearrange_rules grammar =

--- a/src/gen/lib/Nice_typedefs.ml
+++ b/src/gen/lib/Nice_typedefs.ml
@@ -2,11 +2,14 @@
    Improve OCaml type definitions and boilerplate destined for human
    consumption:
 
-   - Inline small definitions that are used only once.
-   - Factor out and name large nodes that occur multiple times.
+   1. Undo the inlining of grammar rules due to the 'inline' field
+      of the grammar.
+   3. Factor out and assign a name to large nodes that occur multiple times.
+   4. Inline small definitions that are used only once.
 *)
 
 let rearrange_rules grammar =
   grammar
+  |> Deinline.deinline_rules
   |> Factorize.factorize_rules
   |> Inline.inline_rules

--- a/src/gen/lib/Simplify_grammar.ml
+++ b/src/gen/lib/Simplify_grammar.ml
@@ -126,6 +126,8 @@ let simplify_grammar grammar =
   let grammar = apply_inline grammar in
   let translate_name = make_name_translator () in
   let simplify = simplify_rule_body translate_name in
+
+  (* Keep inlined rules, which we'll use for deinlining. See Deinlining.ml. *)
   let simplified_rules =
     List.map (fun (name, rule_body) ->
       (translate_name name, simplify rule_body)
@@ -139,7 +141,7 @@ let simplify_grammar grammar =
     conflicts = List.map (List.map translate_name) grammar.conflicts;
     externals = List.map simplify grammar.externals;
     supertypes = [];
-    rules = simplified_rules;
+    rules = simplified_rules; (* includes inlined rules on purpose *)
   }
 
 let run ic oc =

--- a/src/gen/lib/Simplify_grammar.ml
+++ b/src/gen/lib/Simplify_grammar.ml
@@ -62,11 +62,9 @@ let simplify_rule_body translate_name =
      multiple places but for which you don’t want to create syntax tree
      nodes at runtime.
 
-   We perform this inlining here, on 'grammar.json' so we don't have to do
-   it later.
-
-   Alternatively, we could simply set grammar.inline = [] to disable
-   inlining, going against the preferences of the grammar author.
+   We don't mind those extra nodes in the parse tree, but we must perform
+   this inlining to avoid conflicts in the grammar. This is why we must
+   perform this inline here.
 *)
 let apply_inline grammar =
   let rules = Hashtbl.create 100 in
@@ -77,9 +75,6 @@ let apply_inline grammar =
     | None -> () (* could be a warning *)
     | Some body -> Hashtbl.add inline_rules name body
   ) grammar.inline;
-
-  let is_inlined name =
-    Hashtbl.mem inline_rules name in
 
   let get_inlined_body name =
     Hashtbl.find_opt inline_rules name in
@@ -119,11 +114,8 @@ let apply_inline grammar =
     | TOKEN x -> TOKEN (inline parents x)
   in
   let inline_rules rules =
-    List.filter_map (fun (name, body) ->
-      if is_inlined name then
-        None
-      else
-        Some (name, inline [name] body)
+    List.map (fun (name, body) ->
+      (name, inline [name] body)
     ) rules
   in
   { grammar with

--- a/src/gen/lib/Topo_sort.ml
+++ b/src/gen/lib/Topo_sort.ml
@@ -1,10 +1,5 @@
 (*
    Topological sorting of the type definitions.
-
-   We use an off-the-shelf implementation that gives up if any cycle is found.
-   Ideally, we should identify cycles and produce a topologically-sorted
-   list of clusters. Atdgen does this internally but it's not done well
-   and it could be worth revisiting.
 *)
 
 open Printf
@@ -23,11 +18,11 @@ let rec collect_names acc x =
   | Token _
   | Blank -> acc
 
-let extract_rule_deps (name, body) =
-  let deps = collect_names [] body in
+let extract_rule_deps (rule : rule) =
+  let deps = collect_names [] rule.body in
   if debug then
-    printf "%s -> %s\n%!" name (String.concat " " deps);
-  (name, deps)
+    printf "%s -> %s\n%!" rule.name (String.concat " " deps);
+  (rule.name, deps)
 
 (* Generic function on top of Tsort.sort_strongly_connected_components.
    Fails with exception if there's no entry for a dependency. *)

--- a/src/gen/lib/Topo_sort.mli
+++ b/src/gen/lib/Topo_sort.mli
@@ -2,9 +2,6 @@
    Sort rules topologically so as to print out type definitions in the
    order of their dependencies.
 
-   This uses the Containers library.
-   https://c-cube.github.io/ocaml-containers/2.5/containers/CCGraph/index.html
-
    This improves the clarity of the generated code.
    (there are also compile-time performance benefits when generating
    OCaml functions from type definitions)
@@ -15,5 +12,5 @@
    The boolean indicates whether the given rule references itself.
 *)
 val sort :
-  (string * CST_grammar.rule_body) list ->
-  (bool * (string * CST_grammar.rule_body)) list list
+  CST_grammar.rule list ->
+  (bool * CST_grammar.rule) list list

--- a/src/gen/lib/Type_name.mli
+++ b/src/gen/lib/Type_name.mli
@@ -5,7 +5,12 @@
 
 val name_rule_body : CST_grammar.rule_body -> string
 
+(*
+   Assign constructor names suitable for classic variants and polymorphic
+   variants, from rule bodies. The containing rule name is only for
+   better error messages.
+*)
 val assign_case_names :
-  string option ->
+  ?rule_name: string ->
   CST_grammar.rule_body list ->
   (string * CST_grammar.rule_body) list


### PR DESCRIPTION
I left comments in the code describing what I understand about the behavior of tree-sitter. Here's a summary.

Some rules can be hidden, and can be inlined. Inline implies hidden. And we don't support hidden rules because it makes parsing more complicated for us.

* For hidden rules that are not inlined, we've been simply removing the leading underscore, which introduces new nodes in the grammar. No problem with them.
* Inline rules however can't be turned into normal rules without introducing parsing conflicts. What we've been doing is perform the inlining ourselves by rewriting `grammar.json`. This has been working fine too.

The problem here is that the inlined rules have good, meaningful names which are lost during inlining. This set of changes takes care of keeping the inlined rules around. We then use the factorization algorithm to deinline the types and assign them their original names. So we have type definitions that match the rules in the original grammar before inlining, such as

```ocaml
type anon_choice_get = [
     `Get of Token.t (* "get" *)
   | `Set of Token.t (* "set" *)
   | `Async of Token.t (* "async" *)
 ]
```
which is now
```ocaml
type reserved_identifier = [
     `Get of Token.t (* "get" *)
   | `Set of Token.t (* "set" *)
   | `Async of Token.t (* "async" *)
 ]
```

Variant constructor names no longer start with the type name (due to various complications that come with it), so we'll need to chop off the prefix of variants in the existing code e.g.

```ocaml
 type operator = [
    `Op_DOTDOT of Token.t (* ".." *)
  | `Op_BAR of Token.t (* "|" *)
  | `Op_HAT of Token.t (* "^" *)
  | `Op_AMP of Token.t (* "&" *)
```
is now
```ocaml
type operator = [
    `DOTDOT of Token.t (* ".." *)
  | `BAR of Token.t (* "|" *)
  | `HAT of Token.t (* "^" *)
  | `AMP of Token.t (* "&" *)
```

I'll continue with the fixes on semgrep-core on Monday.
