### PR TITLE
Dont call sudo when installing tree sitter in homebrew context

### DIFF
--- a/scripts/install-tree-sitter-lib
+++ b/scripts/install-tree-sitter-lib
@@ -56,7 +56,7 @@ fi
 
   # When building from source on homebrew sudo is not allowed
   # but also not needed
-  if [[ -z "${HOMEBREW_SYSTEM}" ]]; then
+  if [[ -z "${HOMEBREW_SYSTEM+x}" ]]; then
     sudo make install
   else
     make install

--- a/scripts/install-tree-sitter-lib
+++ b/scripts/install-tree-sitter-lib
@@ -53,7 +53,14 @@ fi
   cd tree-sitter
   git clean -dfX
   make
-  sudo make install
+
+  # When building from source on homebrew sudo is not allowed
+  # but also not needed
+  if [[ -z "${HOMEBREW_SYSTEM}" ]]; then
+    sudo make install
+  else
+    make install
+  fi
 
   # Ensure libtree-sitter is found at linking time.
   # MacOS doesn't have ldconfig. Maybe it works without it?


### PR DESCRIPTION
Homebrew does not allow calls to sudo when installing semgrep
from source.