### PR TITLE
Fix release

### DIFF
--- a/lang/Makefile
+++ b/lang/Makefile
@@ -35,6 +35,7 @@ test:
 #
 .PHONY: release
 release:
+	$(MAKE) -C semgrep-grammars
 	./release $(SUPPORTED_LANGUAGES)
 
 .PHONY: clean

--- a/lang/release
+++ b/lang/release
@@ -5,6 +5,11 @@
 #
 set -eu
 
+error() {
+  echo "Error: $*" >&2
+  exit 1
+}
+
 langs=("$@")
 
 id=$(git rev-parse --short HEAD)
@@ -43,6 +48,8 @@ for lang in "${langs[@]}"; do
     if [[ -f "$lang"/orig/LICENSE ]]; then
       cp -a "$lang"/orig/LICENSE "$dst"/orig
     fi
+  else
+    error "Missing folder $lang/ocaml-src"
   fi
 done
 


### PR DESCRIPTION
When running `make release`, this takes care of rebuilding the `grammar.json` for our extended grammars in semgrep-grammars. 

This is something I forgot to do manually last week for javascript and typescript.
