### PR TITLE
Weekly language parsing stats

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -78,12 +78,12 @@ jobs:
 workflows:
   version: 2
 
-  commit:
+  build-on-commit:
     # Default trigger, on commit.
     jobs:
       - build
 
-  weekly:
+  weekly-stats:
     triggers:
       - schedule:
           # Run at 10:00 every Sunday, UTC.
@@ -99,3 +99,9 @@ workflows:
             branches:
               only:
                 - master
+
+  # This is for testing or for forcing a stats job. Requires pushing
+  # to a branch named 'stats'.
+  stats-on-commit:
+    jobs:
+      - stat

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -104,4 +104,9 @@ workflows:
   # to a branch named 'stats'.
   stats-on-commit:
     jobs:
-      - stat
+      - stat:
+          filters:
+            branches:
+              only:
+                - stats
+

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -67,11 +67,11 @@ jobs:
           name: install
           command: opam exec -- make install
       - run:
-          name: build parsers
-          command: opam exec -- make -C lang build
+          name: fetch submodules
+          command: git submodule update --init --recursive
       - run:
           name: run parsing stats
-          command: opam exec -- make -C lang stat
+          command: opam exec -- make stat
       - store_artifacts:
           path: lang/stat.txt
 
@@ -109,4 +109,3 @@ workflows:
             branches:
               only:
                 - stats
-

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -72,6 +72,8 @@ jobs:
       - run:
           name: run parsing stats
           command: opam exec -- make -C lang stat
+      - store_artifacts:
+          path: lang/stat.txt
 
 workflows:
   version: 2

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -42,3 +42,58 @@ jobs:
       - run:
           name: test languages
           command: opam exec -- make lang
+  stat:
+    docker:
+      - image: mjambon/r2c-ocaml:ubuntu
+    working_directory: ~/ocaml-tree-sitter
+    steps:
+      - checkout
+      - run:
+          name: set up node
+          command: ./scripts/setup-node
+      - run:
+          name: install tree-sitter lib
+          command: ./scripts/install-tree-sitter-lib
+      - run:
+          name: configure
+          command: ./configure
+      - run:
+          name: install dependencies
+          command: opam exec -- make setup
+      - run:
+          name: build
+          command: opam exec -- make
+      - run:
+          name: install
+          command: opam exec -- make install
+      - run:
+          name: build parsers
+          command: opam exec -- make -C lang build
+      - run:
+          name: run parsing stats
+          command: opam exec -- make -C lang stat
+
+workflows:
+  version: 2
+
+  commit:
+    # Default trigger, on commit.
+    jobs:
+      - build
+
+  weekly:
+    triggers:
+      - schedule:
+          # Run at 10:00 every Sunday, UTC.
+          cron: "0 10 * * 3"
+          filters:
+            branches:
+              only:
+                - master
+    jobs:
+      - stat:
+          # Run only on these branches (each pushing different images)
+          filters:
+            branches:
+              only:
+                - master

--- a/Makefile
+++ b/Makefile
@@ -65,6 +65,12 @@ lang: build
 	$(MAKE) -C lang build
 	$(MAKE) -C lang test
 
+# Run parsing stats for the supported languages in lang/.
+.PHONY: stat
+stat:
+	$(MAKE) -C lang build
+	$(MAKE) -C lang stat
+
 .PHONY: install
 install:
 	dune install

--- a/lang/.gitignore
+++ b/lang/.gitignore
@@ -7,7 +7,8 @@ Parse_*.ml
 # Various output files
 /*/examples/*.cst
 /*/examples/*.json
-/*/stat.*
+/*/stat.tmp
+/*/stat
 
 node_modules
 package.json

--- a/lang/Makefile
+++ b/lang/Makefile
@@ -14,6 +14,17 @@ SUPPORTED_LANGUAGES = \
   ruby \
   typescript
 
+# Languages which are set up to run parsing stats. Ideally, this is all
+# the supported languages. See the 'stat' target.
+#
+STAT_LANGUAGES = \
+  csharp \
+  go \
+  java \
+  javascript \
+  ruby \
+  typescript
+
 .PHONY: build
 build:
 	$(MAKE) -C semgrep-grammars
@@ -45,6 +56,16 @@ release:
 dry:
 	$(MAKE) -C semgrep-grammars
 	./release --dry-run $(SUPPORTED_LANGUAGES)
+
+# Run parsing stats for each language.
+# Each needs a list of projects (projects.txt) and file extensions
+# (extensions.txt).
+#
+.PHONY: stat
+stat:
+	set -e; \
+	for lang in $(STAT_LANGUAGES); do $(MAKE) -C $$lang stat; done
+	../scripts/report-stat $(STAT_LANGUAGES) | tee stat.txt
 
 .PHONY: clean
 clean:

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -24,6 +24,8 @@ error() {
   exit 1
 }
 
+### Command-line parsing ###
+
 [[ "${BASH_VERSION%%.*}" -ge 4 ]] || error "requires bash >= 4"
 
 if [[ $# != 3 ]]; then
@@ -35,22 +37,7 @@ lang="$1"
 projects_file="$2"
 extensions_file="$3"
 
-# Read lines into array after removing comments and blank lines.
-readarray -t urls < <(grep -v '^ *\(#\| *$\)' "$projects_file")
-readarray -t extensions < <(grep -v '^ *\(#\| *$\)' "$extensions_file")
-
-csv=stat.csv
-tmp=stat.tmp
-failed_inputs=stat.fail
-
-# CSV header
-cat > "$csv" <<EOF
-Name,URL,Files,"Failed files",Lines,"Failed lines",\
-"External errors","Internal errors","Other errors"
-EOF
-
-parser=$(pwd)/ocaml-src/_build/install/default/bin/parse-"$lang"
-test -x "$parser" || error "Missing parser '$parser'."
+### Functions ###
 
 parse() {
   (
@@ -58,7 +45,7 @@ parse() {
     json=out.json
     cst=out.cst
     "$parser" "$input" > /dev/null
-  ) > "$proj_workspace"/parse.log 2>&1
+  ) >> "$proj_err_log" 2>&1
   status=$?
   case "$status" in
     0) ;;
@@ -78,6 +65,8 @@ handle_project() {
   name=$(basename "${url%.git}")
   proj_workspace="$tmp"/"$name"
   mkdir -p "$proj_workspace"
+  proj_err_log="$proj_workspace"/parse-error.log
+  rm -f "$proj_err_log"
   (
     cd "$proj_workspace"
     rm -f inputs
@@ -104,6 +93,7 @@ EOF
       fi
     done
   )
+
   readarray -t inputs < <(cat "$proj_workspace"/inputs)
   num_files=${#inputs[@]}
   echo "Found $num_files files."
@@ -129,6 +119,9 @@ EOF
       echo "  ERROR"
     fi
   done
+
+  # Aggregate results with other projects
+  cat "$proj_err_log" >> "$global_err_log"
   global_line_count=$(( global_line_count + line_count ))
   global_error_line_count=$(( global_error_line_count + error_line_count ))
   cat >> "$csv" <<EOF
@@ -137,26 +130,57 @@ $ext_err_count,$int_err_count,$other_err_count
 EOF
 }
 
-mkdir -p "$tmp"
-rm -f "$failed_inputs"
-global_line_count=0
-global_error_line_count=0
-for url in "${urls[@]}"; do
-  handle_project 2>&1 || echo "Failed on $url" 2>&1 \
-    | tee "$tmp"/lang-stat.log
-done
+main() {
+  # Read lines into array after removing comments and blank lines.
+  readarray -t urls < <(grep -v '^ *\(#\| *$\)' "$projects_file")
+  readarray -t extensions < <(grep -v '^ *\(#\| *$\)' "$extensions_file")
 
-line_coverage=$(awk -f - <<EOF
+  # Workspace, which includes cached git repos.
+  tmp=stat.tmp
+
+  # Output folder, wiped out before every run.
+  stat=stat
+  csv="$stat"/stat.csv
+  failed_inputs="$stat"/stat.fail
+  global_err_log="$stat"/parse-error.log
+
+  parser=$(pwd)/ocaml-src/_build/install/default/bin/parse-"$lang"
+  test -x "$parser" || error "Missing parser '$parser'."
+
+  # Initialize output folder
+  rm -rf "$stat"
+  mkdir -p "$stat"
+
+  # Reuse temporary folder
+  mkdir -p "$tmp"
+  rm -f "$failed_inputs"
+
+  # CSV header
+  cat > "$csv" <<EOF
+Name,URL,Files,"Failed files",Lines,"Failed lines",\
+"External errors","Internal errors","Other errors"
+EOF
+
+  # Run the stats on each git project
+  global_line_count=0
+  global_error_line_count=0
+  for url in "${urls[@]}"; do
+    handle_project 2>&1 || echo "Failed on $url" 2>&1 \
+      | tee "$stat"/lang-stat.log
+  done
+
+  line_coverage=$(awk -f - <<EOF
 BEGIN {
   printf "%.3f%%\n",
   100 * (1 - $global_error_line_count / $global_line_count)
 }
 EOF
-)
+  )
 
-cat <<EOF
-Failed inputs: $failed_inputs
-Result file: $csv
+  tee "$stat"/summary.txt <<EOF
 Line count: $global_line_count
 Line coverage: $line_coverage
 EOF
+}
+
+main

--- a/scripts/report-stat
+++ b/scripts/report-stat
@@ -1,0 +1,46 @@
+#! /usr/bin/env bash
+#
+# Print a summary of the language stats.
+#
+set -eu -o pipefail
+
+prog_name=$(basename "$0")
+
+usage() {
+  cat <<EOF
+Usage: $prog_name [options] LANG1 LANG2 ...
+
+Print a summary of the language stats. Must run from the lang/ folder.
+
+  --help
+      Print this message and exit.
+EOF
+}
+
+langs=()
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --help)
+      usage
+      exit 0
+      ;;
+    *)
+      langs+=("$1")
+  esac
+  shift
+done
+
+commit_id=$(git rev-parse --short HEAD)
+
+cat <<EOF
+=== ocaml-tree-sitter language statistics ===
+date: $(date +%F)
+git commit: $commit_id
+EOF
+
+for lang in "${langs[@]}"; do
+  summary="$lang"/stat/summary.txt
+  echo
+  echo "Language: $lang"
+  cat "$summary"
+done


### PR DESCRIPTION
This branch somewhat improves the language parsing stats and sets up a weekly job. This job takes about 50 minutes at the moment.

In addition to running weekly on the master branch, any push to a branch named `stats` will start a stats job on CircleCI.

A text file summarizing the results is exported as a CircleCI artifact. Here's what we're getting today:
```
=== ocaml-tree-sitter language statistics ===
date: 2020-09-14
git commit: f58d67f

Language: csharp
Line count: 6201840
Line coverage: 82.447%

Language: go
Line count: 7295555
Line coverage: 99.341%

Language: java
Line count: 4695628
Line coverage: 99.863%

Language: javascript
Line count: 889814
Line coverage: 99.797%

Language: ruby
Line count: 4759020
Line coverage: 96.493%

Language: typescript
Line count: 2209782
Line coverage: 78.730%
```

Tasks I'm postponing for now:

* Richer data including html links to the error logs. Those logs are produced locally, just not exported.
* Exporting to a persistent storage facility. CircleCI artifacts persist only 30 days. This will do for now.
