### PR TITLE
Include hash in names created for anonymous nodes

### DIFF
--- a/src/gen/lib/Factorize.ml
+++ b/src/gen/lib/Factorize.ml
@@ -155,7 +155,9 @@ let factorize_rules
       && not (Hashtbl.mem node_names node)
       then
         let name =
-          "anon_" ^ Type_name.name_rule_body node |> make_name_unique in
+          sprintf "anon_%s_%s"
+            (Type_name.name_rule_body node) (Type_name.hash_rule_body node)
+          |> make_name_unique in
         assert (not (Hashtbl.mem new_rules name));
         Hashtbl.add node_names node name;
         Hashtbl.add new_rules name node

--- a/src/gen/lib/Topo_sort.ml
+++ b/src/gen/lib/Topo_sort.ml
@@ -24,15 +24,22 @@ let extract_rule_deps (rule : rule) =
     printf "%s -> %s\n%!" rule.name (String.concat " " deps);
   (rule.name, deps)
 
-(* Generic function on top of Tsort.sort_strongly_connected_components.
-   Fails with exception if there's no entry for a dependency. *)
+(*
+   Generic function on top of Tsort.sort_strongly_connected_components.
+   Fails with exception if there's no entry for a dependency.
+
+   The input is presorted so as to make the output insensitive to
+   the input order.
+*)
 let tsort get_deps elts =
   let deps_data =
     List.map (fun elt ->
       let id, deps = get_deps elt in
+      let deps = List.sort compare deps in
       let self_dep = List.mem id deps in
       (id, deps, self_dep, elt)
     ) elts
+    |> List.sort (fun (a, _, _, _) (b, _, _, _) -> compare a b)
   in
   let tbl = Hashtbl.create 100 in
   List.iter (fun ((id, _, _, _) as x) -> Hashtbl.replace tbl id x) deps_data;

--- a/src/gen/lib/Type_name.ml
+++ b/src/gen/lib/Type_name.ml
@@ -97,7 +97,7 @@ let name_rule_body body =
    Similar to name_rule_body but recursively descend into alternatives,
    producing a longer name. Which is then hashed and discarded.
 *)
-let hash_hex body =
+let hash_rule_body body =
   let buf = Buffer.create 100 in
   let rec aux = function
     | Symbol ident -> Buffer.add_string buf ident
@@ -144,7 +144,7 @@ let assign_case_names ?rule_name:opt_rule_name cases =
       | [] -> assert false
       | rule_bodies ->
           List.map (fun (pos, rule_body) ->
-            let hex_id = hash_hex rule_body in
+            let hex_id = hash_rule_body rule_body in
             (pos, (name ^ "_" ^ hex_id, rule_body))
           ) rule_bodies
     ) grouped

--- a/src/gen/lib/Type_name.mli
+++ b/src/gen/lib/Type_name.mli
@@ -3,8 +3,19 @@
    enclosing rule name and the contents of the production.
 *)
 
+(*
+   Produce a somewhat human-readable name from a rule body.
+   The resulting name may be long and not unique.
+   A hash can be appended to minimize conflicts, see 'hash_rule_body' below.
+*)
 val name_ts_rule_body : Tree_sitter_t.rule_body -> string
 val name_rule_body : CST_grammar.rule_body -> string
+
+(*
+   Produce a hexadecimal hash of the rule body like 'd41d8cd'.
+   These are short and unlikely to conflict with the hash of another rule.
+*)
+val hash_rule_body : CST_grammar.rule_body -> string
 
 (*
    Assign constructor names suitable for classic variants and polymorphic
@@ -15,7 +26,3 @@ val assign_case_names :
   ?rule_name: string ->
   CST_grammar.rule_body list ->
   (string * CST_grammar.rule_body) list
-
-(* Produce a string of 7 hexadecimal digits.
-   This is meant for suggesting stable IDs for arbitrary strings. *)
-val hash_string_hex : string -> string


### PR DESCRIPTION
Implements https://github.com/returntocorp/ocaml-tree-sitter/issues/112

I also added a sorting pass on the list of rules and their dependencies so as to stabilize the order of the definitions (which is the output of topological sort). I updated the generated code in ocaml-tree-sitter-lang in two separate commits to facilitate migration:

1. keep the type names but reorder them according to the new, well-defined order ([bad diff](https://github.com/returntocorp/ocaml-tree-sitter-lang/commit/c5803922c3f1d50a4aede045876f765d265330f5), which doesn't matter).
2. change the type names; their order now mostly remains the same, which results in [good diffs](https://github.com/returntocorp/ocaml-tree-sitter-lang/commit/a887813e00a20f02b3d6337a8b481b35d68fbaab?branch=a887813e00a20f02b3d6337a8b481b35d68fbaab&diff=unified).

I'm now working on the migration in semgrep-core.
