### PR TITLE
Expose detailed parsing error + highlight snippet in test parsers

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,7 +8,7 @@ version: 2.1
 jobs:
   build:
     docker:
-      - image: mjambon/r2c-ocaml:ubuntu
+      - image: returntocorp/ocaml:ubuntu
     working_directory: ~/ocaml-tree-sitter
     steps:
       - checkout

--- a/src/run/lib/Snippet.ml
+++ b/src/run/lib/Snippet.ml
@@ -1,0 +1,167 @@
+(*
+   Functions to extract a good snippet of code, with the error highlighted.
+*)
+
+open Printf
+
+type position = Tree_sitter_bindings.Tree_sitter_output_t.position = {
+  row: int; (* line number, starting from 0. *)
+  column: int; (* position within the line, starting from 0. *)
+}
+
+type snippet_fragment =
+  | Normal of string
+  | Highlight of string
+  | Ellipsis
+
+type snippet_line = snippet_fragment list
+
+type t = snippet_line list
+
+(*
+   Same as String.sub but shrink the requested range to a valid range
+   if needed.
+*)
+let safe_string_sub s orig_start orig_len =
+  let s_len = String.length s in
+  let orig_end = orig_start + orig_len in
+  let start = min s_len (max 0 orig_start) in
+  let end_ = min s_len (max 0 orig_end) in
+  let len = max 0 (end_ - start) in
+  String.sub s start len
+
+let split s pos2 =
+  let a = safe_string_sub s 0 pos2 in
+  let b = safe_string_sub s pos2 (String.length s - pos2) in
+  a, b
+
+let normal_max_length = 120
+let highlight_max_length = 200
+
+let ellide max_len s =
+  assert (max_len >= 2);
+  let len = String.length s in
+  if len > max_len then
+    let len2 = max_len/2 in
+    let a = safe_string_sub s 0 len2 in
+    let b = safe_string_sub s (len-len2) len2 in
+    Some (a, b)
+  else
+    None
+
+let shorten_snippet_line line =
+  List.map (fun frag ->
+    match frag with
+    | Normal s ->
+        (match ellide normal_max_length s with
+         | None -> [frag]
+         | Some (a, b) -> [Normal a; Ellipsis; Normal b]
+        )
+    | Highlight s ->
+        (match ellide highlight_max_length s with
+         | None -> [frag]
+         | Some (a, b) -> [Highlight a; Ellipsis; Highlight b]
+        )
+    | Ellipsis ->
+        [Ellipsis]
+  ) line
+  |> List.flatten
+
+let shorten_snippet_lines lines =
+  List.map shorten_snippet_line lines
+
+let extract
+    ?(lines_before = 2)
+    ?(lines_after = 2)
+    ~start_pos
+    ~end_pos
+    (src : Src_file.t) =
+  let src_line_count = Array.length src.lines in
+  if src_line_count = 0 then []
+  else
+    (*
+       In what follows, 'start' is inclusive and 'end' is exclusive,
+       such that a length is always 'end' - 'start'.
+    *)
+    let start_line = start_pos.row in
+    let end_line = end_pos.row + 1 in
+    let snip_start_line = max (start_line - lines_before) 0 in
+    let snip_end_line = min (end_line + lines_after) src_line_count in
+    let line_acc = ref [] in
+    let add line = line_acc := line :: !line_acc in
+    for line_num = snip_start_line to snip_end_line - 1 do
+      let line = src.lines.(line_num) in
+      if line_num < start_line || line_num >= end_line then
+        (* Highlight nothing. *)
+        add [Normal line]
+      else
+        if start_line = end_line - 1 then
+          (* Highlight substring in the middle of a line. *)
+          let ab, c = split line end_pos.column in
+          let a, b = split ab start_pos.column in
+          add [
+            Normal a;
+            Highlight b;
+            Normal c;
+          ]
+        else if line_num = start_line then
+          (* Highlight the end of the line. *)
+          let a, b = split line start_pos.column in
+          add [
+            Normal a;
+            Highlight b;
+          ]
+        else if line_num = end_line - 1 then
+          (* Highlight the beginning of the line. *)
+          let a, b = split line end_pos.column in
+          add [
+            Highlight a;
+            Normal b;
+          ]
+        else
+          (* Highlight everything. *)
+          add [Highlight line]
+    done;
+    List.rev !line_acc
+    |> shorten_snippet_lines
+
+let ansi_term_highlight s =
+  match s with
+  | "" -> s
+  | s -> ANSITerminal.(sprintf [Bold; red] "%s" s)
+
+let format_line buf ~color line =
+  let highlight =
+    if color then ansi_term_highlight
+    else (fun s -> s)
+  in
+  List.iter (fun frag ->
+    match frag with
+    | Normal s -> Buffer.add_string buf s
+    | Highlight s -> Buffer.add_string buf (highlight s)
+    | Ellipsis -> Buffer.add_string buf "…"
+  ) line;
+  bprintf buf "\n"
+
+let replace s char =
+  String.make (String.length s) char
+
+let format_underline buf ~color line =
+  if not color
+  && List.exists (function Highlight _ -> true | _ -> false) line then (
+    List.iter (fun frag ->
+      match frag with
+      | Normal s -> Buffer.add_string buf (replace s ' ')
+      | Highlight s -> Buffer.add_string buf (replace s '^')
+      | Ellipsis -> Buffer.add_string buf " "
+    ) line;
+    bprintf buf "\n"
+  )
+
+let format ~color lines =
+  let buf = Buffer.create 1000 in
+  List.iter (fun line ->
+    format_line buf ~color line;
+    format_underline buf ~color line;
+  ) lines;
+  Buffer.contents buf

--- a/src/run/lib/Snippet.ml
+++ b/src/run/lib/Snippet.ml
@@ -18,21 +18,9 @@ type snippet_line = snippet_fragment list
 
 type t = snippet_line list
 
-(*
-   Same as String.sub but shrink the requested range to a valid range
-   if needed.
-*)
-let safe_string_sub s orig_start orig_len =
-  let s_len = String.length s in
-  let orig_end = orig_start + orig_len in
-  let start = min s_len (max 0 orig_start) in
-  let end_ = min s_len (max 0 orig_end) in
-  let len = max 0 (end_ - start) in
-  String.sub s start len
-
 let split s pos2 =
-  let a = safe_string_sub s 0 pos2 in
-  let b = safe_string_sub s pos2 (String.length s - pos2) in
+  let a = Util_string.safe_sub s 0 pos2 in
+  let b = Util_string.safe_sub s pos2 (String.length s - pos2) in
   a, b
 
 let normal_max_length = 120
@@ -43,8 +31,8 @@ let ellide max_len s =
   let len = String.length s in
   if len > max_len then
     let len2 = max_len/2 in
-    let a = safe_string_sub s 0 len2 in
-    let b = safe_string_sub s (len-len2) len2 in
+    let a = Util_string.safe_sub s 0 len2 in
+    let b = Util_string.safe_sub s (len-len2) len2 in
     Some (a, b)
   else
     None
@@ -90,7 +78,7 @@ let extract
     let line_acc = ref [] in
     let add line = line_acc := line :: !line_acc in
     for line_num = snip_start_line to snip_end_line - 1 do
-      let line = src.lines.(line_num) in
+      let line = Src_file.safe_get_row src line_num in
       if line_num < start_line || line_num >= end_line then
         (* Highlight nothing. *)
         add [Normal line]

--- a/src/run/lib/Snippet.mli
+++ b/src/run/lib/Snippet.mli
@@ -1,0 +1,37 @@
+(*
+   Functions to extract a good snippet of code, with the error highlighted.
+*)
+
+type position = Tree_sitter_bindings.Tree_sitter_output_t.position = {
+  row: int; (* line number, starting from 0. *)
+  column: int; (* position within the line, starting from 0. *)
+}
+
+type snippet_fragment =
+  | Normal of string
+  | Highlight of string
+  | Ellipsis
+
+type snippet_line = snippet_fragment list
+
+(*
+   A snippet is a list of lines broken up into fragments to be highlighted
+   or not.
+*)
+type t = snippet_line list
+
+(*
+   Extract a snippet from the location in a source file.
+*)
+val extract :
+  ?lines_before:int ->
+  ?lines_after:int ->
+  start_pos:position ->
+  end_pos:position -> Src_file.t -> t
+
+(*
+   Render a snippet as text. If 'color' is true, the output will use
+   color in a manner compatible with an ANSI terminal. Otherwise
+   the text to be highlighted is underlined with '^^^'.
+*)
+val format : color:bool -> t -> string

--- a/src/run/lib/Src_file.ml
+++ b/src/run/lib/Src_file.ml
@@ -7,10 +7,17 @@
    or in characters. Assuming the former for now.
 *)
 
+type info = {
+  name: string;
+  path: string option;
+}
+
 type t = {
-  filename: string;
+  info: info;
   lines: string array;
 }
+
+let info x = x.info
 
 let with_in_channel filename f =
   let ic = open_in filename in
@@ -39,17 +46,25 @@ let read_lines filename =
 
 let load_file src_file =
   {
-    filename = src_file;
+    info = {
+      name = src_file;
+      path = Some src_file;
+    };
     lines = Array.of_list (read_lines src_file);
   }
 
-let load_string ?(src_file = "<source>") src_contents =
+let load_string ?(src_name = "<source>") ?src_file src_contents =
+  let info =
+    match src_file with
+    | None -> { name = src_name; path = None }
+    | Some path -> { name = path; path = Some path }
+  in
   let lines =
     String.split_on_char '\n' src_contents
     |> List.map (fun line -> line ^ "\n")
   in
   {
-    filename = src_file;
+    info;
     lines = Array.of_list lines;
   }
 

--- a/src/run/lib/Src_file.ml
+++ b/src/run/lib/Src_file.ml
@@ -35,7 +35,7 @@ let read_lines filename =
     let acc = ref [] in
     (try
        while true do
-         acc := (input_line ic ^ "\n") :: !acc
+         acc := (input_line ic) :: !acc
        done;
        assert false
      with End_of_file ->
@@ -59,10 +59,7 @@ let load_string ?(src_name = "<source>") ?src_file src_contents =
     | None -> { name = src_name; path = None }
     | Some path -> { name = path; path = Some path }
   in
-  let lines =
-    String.split_on_char '\n' src_contents
-    |> List.map (fun line -> line ^ "\n")
-  in
+  let lines = String.split_on_char '\n' src_contents in
   {
     info;
     lines = Array.of_list lines;

--- a/src/run/lib/Src_file.mli
+++ b/src/run/lib/Src_file.mli
@@ -30,3 +30,10 @@ val load_file : string -> t
 val load_string : ?src_name:string -> ?src_file:string -> string -> t
 
 val get_token : t -> Loc.pos -> Loc.pos -> string
+
+(*
+   Get the specified line from the line array.
+   The first line (row) is numbered 0.
+   If the requested line is out of range, the empty string is returned.
+*)
+val safe_get_row : t -> int -> string

--- a/src/run/lib/Src_file.mli
+++ b/src/run/lib/Src_file.mli
@@ -2,12 +2,15 @@
    Representation of an input file.
 *)
 
-type t
-
 type info = {
   name: string; (* path to the file or to an informal descriptor
                    such as '<stdin>' *)
   path: string option; (* path to the file, if applicable *)
+}
+
+type t = private {
+  info: info;
+  lines: string array;
 }
 
 val info : t -> info

--- a/src/run/lib/Src_file.mli
+++ b/src/run/lib/Src_file.mli
@@ -4,15 +4,26 @@
 
 type t
 
+type info = {
+  name: string; (* path to the file or to an informal descriptor
+                   such as '<stdin>' *)
+  path: string option; (* path to the file, if applicable *)
+}
+
+val info : t -> info
+
 (*
    Load an input file. It gets resolved into lines and columns.
 *)
 val load_file : string -> t
 
 (*
-   Load source code from a string. The optional src_file is for
+   Load source code from a string. The optional 'src_file' is for
    pointing to the source file in error messages.
+   If 'src_file' is unspecified, the name of the file in error messages
+   can be set with 'src_name' without having to be a valid path.
+   The default for 'src_name' is "<source>".
 *)
-val load_string : ?src_file:string -> string -> t
+val load_string : ?src_name:string -> ?src_file:string -> string -> t
 
 val get_token : t -> Loc.pos -> Loc.pos -> string

--- a/src/run/lib/Tree_sitter_error.ml
+++ b/src/run/lib/Tree_sitter_error.ml
@@ -15,6 +15,7 @@ type t = {
   file: Src_file.info;
   start_pos: position;
   end_pos: position;
+  substring: string;
   snippet: Snippet.t;
 }
 
@@ -55,6 +56,7 @@ let create kind src node msg =
     file = Src_file.info src;
     start_pos;
     end_pos;
+    substring = Src_file.get_token src start_pos end_pos;
     snippet = Snippet.extract src ~start_pos ~end_pos;
   }
 

--- a/src/run/lib/Tree_sitter_error.ml
+++ b/src/run/lib/Tree_sitter_error.ml
@@ -5,12 +5,25 @@
 open Printf
 open Tree_sitter_bindings.Tree_sitter_output_t
 
-exception External_error of string
-exception Internal_error of string
+type kind =
+  | Internal (* a bug *)
+  | External (* malformed input or bug, but we don't know *)
 
+type t = {
+  kind: kind;
+  msg: string;
+  file: Src_file.info;
+  start_pos: position;
+  end_pos: position;
+  snippet: string * string * string;
+}
+
+exception Error of t
+
+(* TODO: include up to 2 lines of context before and after the error. *)
 let format_snippet src start end_ =
   let snippet = Src_file.get_token src start end_ in
-  sprintf "%s\n" snippet
+  "", snippet, "\n"
 
 let string_of_node_type x =
   match x.children with
@@ -32,13 +45,52 @@ children: [
         (List.map (fun x -> sprintf "  %s\n" (string_of_node_type x)) children
          |> String.concat "")
 
+let create kind src node msg =
+  let msg = sprintf "\
+%s
+%s"
+      (string_of_node node)
+      msg
+  in
+  let start_pos = node.start_pos in
+  let end_pos = node.end_pos in
+  {
+    kind;
+    msg;
+    file = Src_file.info src;
+    start_pos;
+    end_pos;
+    snippet = format_snippet src start_pos end_pos;
+  }
+
+let fail kind src node msg =
+  raise (Error (create kind src node msg))
+
+let external_error src node msg =
+  fail External src node msg
+
+let internal_error src node msg =
+  fail Internal src node msg
+
+let ansi_highlight s =
+  match s with
+  | "" -> s
+  | s -> ANSITerminal.(sprintf [Bold; red] "%s" s)
+
+let format_snippet ~color (a, b, c) =
+  let b =
+    if color then ansi_highlight b
+    else b
+  in
+  a ^ b ^ c
+
 (* Take an error message and prepend the location information,
    in a human-readable and possibly computer-readable format (TODO check with
    emacs etc.)
 *)
-let prepend_msg src node msg =
-  let start = node.start_pos in
-  let end_ = node.end_pos in
+let to_string ?(color = false) (err : t) =
+  let start = err.start_pos in
+  let end_ = err.end_pos in
   let loc =
     if start.row = end_.row then
       sprintf "Line %i, characters %i-%i:"
@@ -47,22 +99,10 @@ let prepend_msg src node msg =
       sprintf "Line %i, character %i to line %i, character %i:"
         start.row start.column end_.row end_.column
   in
-  let snippet = format_snippet src start end_ in
   sprintf "\
 %s
 %s
-source code:
-%s
 %s"
     loc
-    (string_of_node node)
-    snippet
-    msg
-
-let external_error src node msg =
-  let msg = prepend_msg src node msg in
-  raise (External_error msg)
-
-let internal_error src node msg =
-  let msg = prepend_msg src node msg in
-  raise (Internal_error msg)
+    (format_snippet ~color err.snippet)
+    err.msg

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -12,7 +12,7 @@ type t = {
   file: Src_file.info;
   start_pos: Tree_sitter_bindings.Tree_sitter_output_t.position;
   end_pos: Tree_sitter_bindings.Tree_sitter_output_t.position;
-  snippet: string * string * string;
+  snippet: Snippet.t;
 }
 
 (* Fatal parsing error. *)

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -24,6 +24,13 @@ type t = {
   end_pos: Tree_sitter_bindings.Tree_sitter_output_t.position;
 
   (*
+     The region of the code (tree-sitter error node) reported as an error.
+     This could almost be extracted from the snippet field, but here we
+     guarantee no ellipsis.
+  *)
+  substring: string;
+
+  (*
      A structured snippet of code extracted from the source input,
      including lines of context, regions to be highlighted, and ellipses
      if a string is too long. See Snippet.format for rendering

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -2,23 +2,21 @@
    Error message formatting.
 *)
 
-(*
-   Fatal syntax error due to bad input or a bad grammar.
+type kind =
+  | Internal (* a bug *)
+  | External (* malformed input or bug, but we don't know *)
 
-   The argument is a preformatted, multiline error message similar to
-   the argument of a Failure exception. Doesn't benefit from showing
-   a stack trace.
-*)
-exception External_error of string
+type t = {
+  kind: kind;
+  msg: string;
+  file: Src_file.info;
+  start_pos: Tree_sitter_bindings.Tree_sitter_output_t.position;
+  end_pos: Tree_sitter_bindings.Tree_sitter_output_t.position;
+  snippet: string * string * string;
+}
 
-(*
-   Fatal error due to a bug in the code being executed.
-
-   The argument is a preformatted, multiline error message similar to
-   the argument of a Failure exception. Doesn't benefit from showing
-   a stack trace.
-*)
-exception Internal_error of string
+(* Fatal parsing error. *)
+exception Error of t
 
 (*
    Fail, raising an External_error exception.
@@ -39,3 +37,9 @@ val internal_error :
   Src_file.t ->
   Tree_sitter_bindings.Tree_sitter_output_t.node ->
   string -> 'a
+
+(*
+   Format an error message. Highlight the error for an ANSI terminal iff
+   'color' is true. 'color' is false by default.
+*)
+val to_string : ?color:bool -> t -> string

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -9,9 +9,26 @@ type kind =
 type t = {
   kind: kind;
   msg: string;
+
+  (*
+     Provides the path to the source file if applicable.
+  *)
   file: Src_file.info;
+
+  (*
+     Beginning and end of the error node reported by tree-sitter.
+     The end position is inclusive, i.e. it's the position of the last
+     character of the selected region.
+  *)
   start_pos: Tree_sitter_bindings.Tree_sitter_output_t.position;
   end_pos: Tree_sitter_bindings.Tree_sitter_output_t.position;
+
+  (*
+     A structured snippet of code extracted from the source input,
+     including lines of context, regions to be highlighted, and ellipses
+     if a string is too long. See Snippet.format for rendering
+     to a terminal or as plain text.
+  *)
   snippet: Snippet.t;
 }
 

--- a/src/run/lib/Util_string.ml
+++ b/src/run/lib/Util_string.ml
@@ -1,0 +1,11 @@
+(*
+   Various string manipulation functions that need unit tests.
+*)
+
+let safe_sub s orig_start orig_len =
+  let s_len = String.length s in
+  let orig_end = orig_start + orig_len in
+  let start = min s_len (max 0 orig_start) in
+  let end_ = min s_len (max 0 orig_end) in
+  let len = max 0 (end_ - start) in
+  String.sub s start len

--- a/src/run/lib/Util_string.mli
+++ b/src/run/lib/Util_string.mli
@@ -1,0 +1,14 @@
+(*
+   Various string manipulation functions that need unit tests.
+*)
+
+(*
+   Same as String.sub but shrink the requested range to a valid range
+   if needed. It will not raise an exception due to an invalid range.
+
+   Examples:
+     safe_string_sub "abcd" 1 2    = "bc"  (* valid range *)
+     safe_string_sub "abcd" (-1) 2 = "a"   (* partially valid range *)
+     safe_string_sub "abcd" (-5) 2 = ""    (* completely invalid range *)
+*)
+val safe_sub : string -> int -> int -> string

--- a/src/run/lib/dune
+++ b/src/run/lib/dune
@@ -3,8 +3,9 @@
  (name tree_sitter_run)
  (preprocess (pps ppx_sexp_conv))
  (libraries
+   ANSITerminal
+   sexplib
    tree-sitter.gen
    tree-sitter.bindings
-   sexplib
  )
 )

--- a/src/run/test/Util_string.ml
+++ b/src/run/test/Util_string.ml
@@ -1,0 +1,30 @@
+(*
+   Test the Util_string module.
+*)
+
+open Tree_sitter_run
+
+let safe_sub_cases = [
+  "", 0, 0, "";
+  "abcd", 0, 4, "abcd";
+  "abcd", 0, 2, "ab";
+  "abcd", 2, 2, "cd";
+  "", (-1), 1, "";
+  "", 1, 1, "";
+  "abcd", (-1), 2, "a";
+  "abcd", 3, 2, "d";
+  "abcd", (-1), 6, "abcd";
+]
+
+let test_safe_sub () =
+  let check (src, pos, len, res) =
+    Alcotest.(check string)
+      "equal"
+      (Util_string.safe_sub src pos len)
+      res
+  in
+  List.iter check safe_sub_cases
+
+let test = "Util_string", [
+  "safe_sub", `Quick, test_safe_sub;
+]

--- a/src/run/test/test.ml
+++ b/src/run/test/test.ml
@@ -3,5 +3,6 @@
 *)
 
 let test_suites : unit Alcotest.test list = [
+  Util_string.test;
   Matcher.test;
 ]

--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -15,7 +15,7 @@ install: [make "install"]
 
 depends: [
   "alcotest"
-  "ansiterminal"
+  "ANSITerminal"
   "atdgen"
   "cmdliner"
   "conf-pkg-config"

--- a/tree-sitter.opam
+++ b/tree-sitter.opam
@@ -15,6 +15,7 @@ install: [make "install"]
 
 depends: [
   "alcotest"
+  "ansiterminal"
   "atdgen"
   "cmdliner"
   "conf-pkg-config"


### PR DESCRIPTION
A new Error exception is now exposed and designed to be caught an interpreted by the caller. See `Tree_sitter_error.mli`.

Additionally, the error is shown in context when it occurs in a test parser, with color if printing to a terminal:

![image](https://user-images.githubusercontent.com/343265/94759061-c065d480-0353-11eb-8e19-b5afce34ad3f.png)

or otherwise as plain text:

```
Error: Line 2, characters 15-17:
function f() {
  thing (); uh oh; thang();
               ^^          
}

node type: ERROR
children: [
  identifier
]
Source code cannot be parsed by tree-sitter.

exit 11
```

It also takes care of truncating strings that are too long so this doesn't result in a disaster when printing error lines from minified files:

![image](https://user-images.githubusercontent.com/343265/94759352-86e19900-0354-11eb-9468-d501bea564e1.png)

Takes care of https://github.com/returntocorp/ocaml-tree-sitter/issues/110