### PR TITLE
json file changed, otherwise git status shows up as unclean

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,12 @@
+{
+  "dependencies": {
+    "tree-sitter-c-sharp": "file:lang/semgrep-grammars/src/tree-sitter-c-sharp",
+    "tree-sitter-javascript": "file:lang/semgrep-grammars/src/tree-sitter-javascript",
+    "tree-sitter-kotlin": "file:lang/semgrep-grammars/src/tree-sitter-kotlin",
+    "tree-sitter-lua": "file:lang/semgrep-grammars/src/tree-sitter-lua",
+    "tree-sitter-r": "file:lang/semgrep-grammars/src/tree-sitter-r",
+    "tree-sitter-ruby": "file:lang/semgrep-grammars/src/tree-sitter-ruby",
+    "tree-sitter-rust": "file:lang/semgrep-grammars/src/tree-sitter-rust",
+    "tree-sitter-typescript": "file:lang/semgrep-grammars/src/tree-sitter-typescript"
+  }
+}


### PR DESCRIPTION
When running 

```make release``` 

with the new semgrep-grammars repo, package.json file changes and I can't make a push to ocaml-tree-sitter-lang because the git status is unclean. 

Hopefully with this we're able to push to ocaml-tree-sitter-lang.