### PR TITLE
Fix script in charge of installing the tree-sitter runtime library

### DIFF
--- a/scripts/install-tree-sitter-lib
+++ b/scripts/install-tree-sitter-lib
@@ -45,10 +45,14 @@ while [[ $# -gt 0 ]]; do
 done
 
 echo "Installing tree-sitter library directly from git."
-if [[ ! -e tree-sitter ]]; then
-  git clone --depth 1 --branch "$version" \
-    https://github.com/tree-sitter/tree-sitter.git
+if [[ -d tree-sitter ]]; then
+  echo "Removing previous copy of tree-sitter."
+  rm -rf tree-sitter
 fi
+echo "Fetching tree-sitter from git, branch $version."
+git clone --depth 1 --branch "$version" \
+    https://github.com/tree-sitter/tree-sitter.git
+
 (
   cd tree-sitter
   git clean -dfX


### PR DESCRIPTION
It was not fetching the requested tree-sitter code if an older version had already been checked out previously.