### PR TITLE
Write parsing stats' error log in json format

### DIFF
--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -44,7 +44,9 @@ parse() {
     cd "$proj_workspace"
     json=out.json
     cst=out.cst
-    "$parser" "$input" > /dev/null
+    "$parser" "$input" \
+      --txt-stat stat.txt \
+      --json-error-log "$global_json_err_log" > /dev/null
   ) >> "$proj_err_log" 2>&1
   status=$?
   case "$status" in
@@ -144,10 +146,11 @@ main() {
   tmp=stat.tmp
 
   # Output folder, wiped out before every run.
-  stat=stat
+  stat=$(pwd)/stat
   csv="$stat"/stat.csv
   failed_inputs="$stat"/stat.fail
   global_err_log="$stat"/parse-error.log
+  global_json_err_log="$stat"/parse-error.json
 
   parser=$(pwd)/ocaml-src/_build/install/default/bin/parse-"$lang"
   test -x "$parser" || error "Missing parser '$parser'."

--- a/src/run/lib/Run.ml
+++ b/src/run/lib/Run.ml
@@ -196,7 +196,8 @@ let extract_error_nodes root_node =
 let extract_errors src root_node =
   extract_error_nodes root_node
   |> List.map (fun (parent, error_node) ->
-    Tree_sitter_error.create Tree_sitter_error.External src ?parent error_node
+    Tree_sitter_error.create
+      Tree_sitter_error_t.External src ?parent error_node
       "Unrecognized construct"
   )
 

--- a/src/run/lib/Tree_sitter_error.atd
+++ b/src/run/lib/Tree_sitter_error.atd
@@ -1,0 +1,28 @@
+(*
+   Type definition for json errors exported by the test parsers.
+*)
+
+type node_kind <ocaml from="Tree_sitter_bindings.Tree_sitter_output"
+                      t="node_kind"> = abstract
+
+type position <ocaml from="Tree_sitter_bindings.Tree_sitter_output"
+                     t="position"> = abstract
+
+type error_kind = [
+  | Internal (* a bug *)
+  | External (* malformed input or bug, but we don't know *)
+] <ocaml repr="classic">
+
+(*
+   Simplified type suitable for json export.
+   The original type is Tree_sitter_error.t (in Tree_sitter_error.mli).
+*)
+type json_error = {
+  kind: error_kind;
+  msg: string;
+  file: string;
+  start_pos: position;
+  end_pos: position;
+  substring: string;
+  ?error_class: string option;
+}

--- a/src/run/lib/Tree_sitter_error.mli
+++ b/src/run/lib/Tree_sitter_error.mli
@@ -2,10 +2,6 @@
    Error message formatting.
 *)
 
-type error_kind =
-  | Internal (* a bug *)
-  | External (* malformed input or bug, but we don't know *)
-
 (*
    The goal of this error_class object is to classify errors.
    It is applicable to ERROR nodes found in the tree-sitter output.
@@ -31,7 +27,7 @@ type error_class = {
 val string_of_error_class : error_class -> string
 
 type t = {
-  kind: error_kind;
+  kind: Tree_sitter_error_t.error_kind;
   msg: string;
 
   (*
@@ -76,7 +72,7 @@ exception Error of t
    a parsing error.
 *)
 val create :
-  error_kind ->
+  Tree_sitter_error_t.error_kind ->
   Src_file.t ->
   ?parent:Tree_sitter_bindings.Tree_sitter_output_t.node ->
   Tree_sitter_bindings.Tree_sitter_output_t.node ->
@@ -107,3 +103,11 @@ val internal_error :
    'color' is true. 'color' is false by default.
 *)
 val to_string : ?color:bool -> t -> string
+
+(*
+   Append errors to error log in json format, one object per line.
+
+   The specific json format is unspecified and might change. This is for
+   internal use within ocaml-tree-sitter.
+*)
+val log_json_errors : string -> t list -> unit

--- a/src/run/lib/dune
+++ b/src/run/lib/dune
@@ -4,8 +4,22 @@
  (preprocess (pps ppx_sexp_conv))
  (libraries
    ANSITerminal
+   atdgen-runtime
+   cmdliner
    sexplib
    tree-sitter.gen
    tree-sitter.bindings
  )
 )
+
+; atdgen preprocessing for json support
+(rule
+ (targets Tree_sitter_error_j.ml Tree_sitter_error_j.mli)
+ (deps    Tree_sitter_error.atd)
+ (action  (run atdgen -j -j-std %{deps})))
+
+; atdgen preprocessing for json support
+(rule
+ (targets Tree_sitter_error_t.ml Tree_sitter_error_t.mli)
+ (deps    Tree_sitter_error.atd)
+ (action  (run atdgen -t %{deps})))


### PR DESCRIPTION
`make stat` in a folder like `lang/scala` now produces a file `stat/parse-error.json`. This allows an external tool such as a python script to attempt clustering the errors by `error_class`, to help make sense of which errors are most common.

Here's some sample output for `lang/javascript`:
```
$ ydump stat/parse-error.json 
{
  "kind": "External",
  "msg":
    "node type: ERROR\nchildren: [\n  number\n  \":\"\n]\nUnrecognized construct",
  "file": "three.js/examples/js/libs/draco/draco_encoder.js",
  "start_pos": { "row": 9, "column": 134394 },
  "end_pos": { "row": 9, "column": 134396 },
  "substring": "5:",
  "error_class":
    "parent: member_expression, left sibling: \"?.\", first child: number"
}
{
  "kind": "External",
  "msg":
    "node type: ERROR\nchildren: [\n  number\n  \":\"\n]\nUnrecognized construct",
  "file": "three.js/examples/js/libs/draco/draco_decoder.js",
  "start_pos": { "row": 20, "column": 175909 },
  "end_pos": { "row": 20, "column": 175911 },
  "substring": "5:",
  "error_class":
    "parent: call_expression, left sibling: \"?.\", first child: number"
}
{
  "kind": "External",
  "msg":
    "node type: ERROR\nchildren: [\n  number\n  \":\"\n]\nUnrecognized construct",
  "file": "three.js/examples/js/libs/draco/gltf/draco_encoder.js",
  "start_pos": { "row": 9, "column": 127925 },
  "end_pos": { "row": 9, "column": 127927 },
  "substring": "5:",
  "error_class":
    "parent: member_expression, left sibling: \"?.\", first child: number"
}
{
  "kind": "External",
  "msg":
    "node type: ERROR\nchildren: [\n  number\n  \":\"\n]\nUnrecognized construct",
  "file": "three.js/examples/js/libs/draco/gltf/draco_decoder.js",
  "start_pos": { "row": 16, "column": 169404 },
  "end_pos": { "row": 16, "column": 169406 },
  "substring": "5:",
  "error_class":
    "parent: call_expression, left sibling: \"?.\", first child: number"
}
{
  "kind": "External",
  "msg":
    "node type: ERROR\nchildren: [\n  \"as\"\n  identifier\n]\nUnrecognized construct",
  "file": "material-ui/test/utils/index.js",
  "start_pos": { "row": 15, "column": 9 },
  "end_pos": { "row": 15, "column": 29 },
  "substring": "as fireDiscreteEvent",
  "error_class":
    "parent: export_statement, left sibling: \"*\", first child: \"as\""
}
```
