### PR TITLE
Aggregate errors by "class"

### DIFF
--- a/scripts/aggregate-parse-errors
+++ b/scripts/aggregate-parse-errors
@@ -1,0 +1,44 @@
+#! /usr/bin/env python3
+#
+# Aggregate parse errors into classes so as to give a sense of which errors are
+# more common or serious for a given parser.
+#
+
+import csv
+import json
+import sys
+
+def parse_json_error_log():
+    clusters = {}
+    for line in sys.stdin:
+        err = json.loads(line)
+        if 'error_class' in err:
+            key = err['error_class']
+            if not key in clusters:
+                clus = {
+                    'error_class': key,
+                    'num_errors': 0,
+                    'num_lines': 0,
+                }
+                clusters[key] = clus
+            clus = clusters[key]
+            clus['num_errors'] = clus['num_errors'] + 1
+            err_num_lines = err['end_pos']['row'] - err['start_pos']['row'] + 1
+            clus['num_lines'] = clus['num_lines'] + err_num_lines
+    return clusters
+
+
+def print_csv_clusters(clusters):
+    for key, clus in clusters.items():
+        writer = csv.writer(sys.stdout, quoting=csv.QUOTE_MINIMAL)
+        row = [clus['num_errors'], clus['num_lines'], clus['error_class']]
+        writer.writerow(row)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) == 1:
+        clusters = parse_json_error_log()
+        print_csv_clusters(clusters)
+    else:
+        print("reads records from a parse-error.json file on stdin")
+        sys.exit(1)

--- a/scripts/lang-stat
+++ b/scripts/lang-stat
@@ -5,6 +5,7 @@
 #
 set -eu -o pipefail
 
+progdir=$(dirname "$0")
 progname=$(basename "$0")
 
 usage() {
@@ -137,6 +138,20 @@ $ext_err_count,$int_err_count,$other_err_count
 EOF
 }
 
+aggregate_errors() {
+  header='num_errors,num_lines,error_class'
+  (
+    echo "$header"
+    "$progdir"/aggregate-parse-errors < "$global_json_err_log" \
+      | sort -rn -t, -k1 -k2
+  ) > "$stat"/aggregated-errors-sorted-by-count.csv
+  (
+    echo "$header"
+    "$progdir"/aggregate-parse-errors < "$global_json_err_log" \
+      | sort -rn -t, -k2 -k1
+  ) > "$stat"/aggregated-errors-sorted-by-line-count.csv
+}
+
 main() {
   # Read lines into array after removing comments and blank lines.
   readarray -t urls < <(grep -v '^ *\(#\| *$\)' "$projects_file")
@@ -176,6 +191,8 @@ EOF
     handle_project 2>&1 || echo "Failed on $url" 2>&1 \
       | tee "$stat"/lang-stat.log
   done
+
+  aggregate_errors
 
   line_coverage=$(awk -f - <<EOF
 BEGIN {


### PR DESCRIPTION
It's now part of `make stat`. Two CSV files are generated, showing which errors are more common, according to the number of errors or according to the number of lines affected.

This is what I get with javascript (not many errors):
![image](https://user-images.githubusercontent.com/343265/112707264-52641b00-8e67-11eb-846d-058b9a5b8029.png)
