### PR TITLE
semgrep-rust: Support top-level statements

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-rust/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-rust/grammar.js
@@ -16,12 +16,16 @@ module.exports = grammar(standard_grammar, {
     source_file: ($, previous) => {
       return choice(
         previous,
-        $.semgrep_expression
+        $.semgrep_expression,
+        $.semgrep_statement,
       );
     },
 
     // Alternate "entry point". Allows parsing a standalone expression.
     semgrep_expression: $ => seq('__SEMGREP_EXPRESSION', $._expression),
+
+    // Alternate "entry point". Allows parsing a standalone list of statements.
+    semgrep_statement: $ => seq('__SEMGREP_STATEMENT', repeat1($._statement)),
 
     // Metavariables
     identifier: ($, previous) => {

--- a/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
@@ -173,6 +173,52 @@ __SEMGREP_EXPRESSION
 (source_file (semgrep_expression (integer_literal)))
 
 =====================================
+Toplevel single statement
+=====================================
+
+__SEMGREP_STATEMENT
+let mut x = 0;
+
+---
+
+(source_file
+  (semgrep_statement
+    (let_declaration
+      (mutable_specifier)
+      (identifier)
+      (integer_literal)
+    )
+  )
+)
+
+=====================================
+Toplevel multiple statements
+=====================================
+
+__SEMGREP_STATEMENT
+let mut x = 0;
+let y = x * 2;
+
+---
+
+(source_file
+  (semgrep_statement
+    (let_declaration
+      (mutable_specifier)
+      (identifier)
+      (integer_literal)
+    )
+    (let_declaration
+      (identifier)
+      (binary_expression
+        (identifier)
+        (integer_literal)
+      )
+    )
+  )
+)
+
+=====================================
 Argument ellipsis
 =====================================
 


### PR DESCRIPTION
This should make it possible to write Rust semgrep patterns with a list of statements directly.