### PR TITLE
Add vanilla semgrep setup

### DIFF
--- a/.github/workflows/semgrep.yml
+++ b/.github/workflows/semgrep.yml
@@ -1,0 +1,13 @@
+name: Semgrep
+on: [pull_request]
+jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    name: Check
+    steps:
+      - uses: actions/checkout@v1
+      - name: Semgrep
+        id: semgrep
+        uses: returntocorp/semgrep-action@v1
+        with:
+          config: p/r2c


### PR DESCRIPTION
This is a copy-paste of the setup shown on the [GHA page](https://github.com/marketplace/actions/semgrep-action), which is the landing page from the [documentation](https://semgrep.dev/docs/semgrep-ci/) found when searching the web for "install semgrep".