### PR TITLE
Parameter ellipsis

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -40,9 +40,11 @@ module.exports = grammar(standard_grammar, {
     identifier: ($, previous) => {
       return choice(
         previous,
-        token(/\$[A-Z_][A-Z_0-9]*/)
+        _semgrep_metavariable
       );
     },
+
+    _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
 
     // Statement ellipsis: '...' not followed by ';'
     expression_statement: ($, previous) => {

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -23,6 +23,11 @@ module.exports = grammar(standard_grammar, {
   */
   name: 'c_sharp',
 
+  conflicts: ($, previous) => [
+    ...previous,
+    [$._expression, $.parameter]
+  ],
+
   rules: {
 
     // Entry point
@@ -40,11 +45,18 @@ module.exports = grammar(standard_grammar, {
     identifier: ($, previous) => {
       return choice(
         previous,
-        _semgrep_metavariable
+        $._semgrep_metavariable
       );
     },
 
     _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
+
+    parameter: ($, previous) => {
+      return choice(
+        previous,
+        $.ellipsis
+      );
+    },
 
     // Statement ellipsis: '...' not followed by ';'
     expression_statement: ($, previous) => {

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -173,3 +173,32 @@ foo(...)
     )
   )
 )
+
+=====================================
+Parameter ellipsis in method definition
+=====================================
+
+class A {
+  public void SomeMethod(..., string p, ...) {
+  }
+}
+
+---
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (declaration_list
+      (method_declaration
+        (modifier)
+        (void_keyword)
+        (identifier)
+        (parameter_list
+          (parameter
+            (ellipsis))
+          (parameter
+            (predefined_type)
+            (identifier))
+          (parameter
+            (ellipsis)))
+        (block)))))


### PR DESCRIPTION
Support parameter ellipsis
    
Parameters in method definitions can be ellipsis. Since elllipsis can now be
expressions and parameters, we add a conflict rule.
    
Related to https://github.com/returntocorp/semgrep/issues/3289
