### PR TITLE
fix(typescript): allow object destructuring patterns as semgrep patterns

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
+++ b/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
@@ -80,6 +80,10 @@ module.exports = {
       $.finally_clause,
       $.catch_clause,
       $.assign_lambda,
+      // Allows standalone object destructuring patterns like `{$A = $B}`,
+      // which are otherwise unreachable from `expression`.
+      // See https://github.com/semgrep/semgrep/issues/2117.
+      $.object_pattern,
     ),
 
     method_pattern: $ => choice(

--- a/lang/typescript/test/ok/semgrep/object_assignment_pattern.sgrep
+++ b/lang/typescript/test/ok/semgrep/object_assignment_pattern.sgrep
@@ -1,0 +1,1 @@
+__SEMGREP_EXPRESSION {$A = $B}

--- a/lang/typescript/test/ok/semgrep/object_pattern_mixed.sgrep
+++ b/lang/typescript/test/ok/semgrep/object_pattern_mixed.sgrep
@@ -1,0 +1,1 @@
+__SEMGREP_EXPRESSION {$A = '', $C, $D: $E = 1}


### PR DESCRIPTION
## Summary

- `__SEMGREP_EXPRESSION` routes through `semgrep_pattern`, which previously could only reach `object_pattern` indirectly via `expression` (an `object`). Since `object` does not admit `object_assignment_pattern`, patterns like `{$A = $B}` failed to parse and produced ERROR nodes.
- Add `object_pattern` as a direct alternative of `semgrep_pattern` so destructuring-with-default patterns parse cleanly. No new grammar conflicts.
- Adds two `.sgrep` tests covering the ticket's example and a mixed object-pattern form.

Fixes semgrep/semgrep#2117.

## Test plan

- [x] Regenerate `typescript` and `tsx` parsers with `make build` under `lang/semgrep-grammars/src/semgrep-typescript` — no new conflicts reported.
- [x] Verify both new test files parse cleanly (exit 0) with the fix.
- [x] Verify both test files produced ERROR nodes on the baseline (pre-fix) parser, confirming the bug and the fix.
- [ ] CI passes on this branch.