### PR TITLE
[java] fix Semgrep pattern parsing for switch/enum/annotation positions

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-java/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-java/grammar.js
@@ -41,6 +41,12 @@ module.exports = grammar(base_grammar, {
 
     // this is from adding toplevel_explicit_constructor_invocation
     [$.type_parameter, $._unannotated_type],
+
+    // LANG-467: A bare `$...META` (or `...`) after `{` could be parsed as
+    // either an enum-constants list element or as the body of
+    // `enum_body_declarations`. GLR resolves this; the parses are
+    // operationally equivalent for Semgrep's purposes.
+    [$.enum_body, $.enum_body_declarations],
   ]),
 
   rules: {
@@ -65,9 +71,43 @@ module.exports = grammar(base_grammar, {
       $.toplevel_explicit_constructor_invocation,
     ),
 
+    // LANG-467: Allow `...` and `$...META` in the enum-constants list, and
+    // allow `$...META` (in addition to `...`) inside the post-`;` body region.
+    // Override `enum_body` wholesale since the constants list itself needs
+    // ellipsis support, which can't be reached via a `previous`-style
+    // augmentation.
+    enum_body: $ => seq(
+      '{',
+      commaSep(choice(
+        $.enum_constant,
+        $.semgrep_ellipsis,
+        $.semgrep_named_ellipsis,
+      )),
+      optional(','),
+      optional($.enum_body_declarations),
+      '}',
+    ),
+
     enum_body_declarations: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,
+      $.semgrep_named_ellipsis,
+    ),
+
+    // LANG-466: allow `...` (and `$...META`) interleaved with arrow-rule
+    // switch entries. The colon-form arm already supports ellipsis via the
+    // `statement` augmentation; the arrow-rule arm needs explicit support.
+    switch_block: $ => seq(
+      '{',
+      choice(
+        repeat($.switch_block_statement_group),
+        repeat(choice(
+          $.switch_rule,
+          $.semgrep_ellipsis,
+          $.semgrep_named_ellipsis,
+        )),
+      ),
+      '}',
     ),
 
     // This is a copy of `explicit_constructor_invocation`,
@@ -111,10 +151,13 @@ module.exports = grammar(base_grammar, {
       '}',
     ),
 
-    // So we can put ellipses within annotation type declarations
+    // So we can put ellipses within annotation type declarations.
+    // LANG-469: also allow `$...META` so `@interface $A { $...ELEMENTS }`
+    // parses cleanly.
     annotation_type_element_declaration: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,
+      $.semgrep_named_ellipsis,
     ),
 
     semgrep_ellipsis: $ => '...',
@@ -173,9 +216,12 @@ module.exports = grammar(base_grammar, {
       field('field', choice($.identifier, $._reserved_identifier, $.this, '...')),
     ),
 
+    // LANG-469: also allow `$...META` so patterns like
+    // `@$ANN(value = "...", $...PROPS)` parse cleanly.
     element_value_pair: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,
+      $.semgrep_named_ellipsis,
     ),
 
 

--- a/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-java/test/corpus/semgrep.txt
@@ -538,3 +538,99 @@ try { ... }
     (partial_try_statement
       (block
         (semgrep_ellipsis)))))
+
+================================================================================
+Ellipsis between switch arrow rules (LANG-466)
+================================================================================
+
+switch ($X) {
+  case $C -> $E;
+  ...
+}
+
+--------------------------------------------------------------------------------
+
+(program
+  (switch_expression
+    (parenthesized_expression
+      (identifier))
+    (switch_block
+      (switch_rule
+        (switch_label
+          (identifier))
+        (expression_statement
+          (identifier)))
+      (semgrep_ellipsis))))
+
+================================================================================
+Ellipsis and named ellipsis in enum body (LANG-467)
+================================================================================
+
+enum $E { $A, $B, ...; }
+
+--------------------------------------------------------------------------------
+
+(program
+  (enum_declaration
+    (identifier)
+    (enum_body
+      (enum_constant
+        (identifier))
+      (enum_constant
+        (identifier))
+      (semgrep_ellipsis)
+      (enum_body_declarations))))
+
+================================================================================
+Named ellipsis as enum constants list (LANG-467)
+================================================================================
+
+enum $E { $...CONSTS; ... }
+
+--------------------------------------------------------------------------------
+
+(program
+  (enum_declaration
+    (identifier)
+    (enum_body
+      (semgrep_named_ellipsis)
+      (enum_body_declarations
+        (semgrep_ellipsis)))))
+
+================================================================================
+Named ellipsis in annotation argument list (LANG-469)
+================================================================================
+
+@$ANN(value = "x", $...PROPS) class C {}
+
+--------------------------------------------------------------------------------
+
+(program
+  (class_declaration
+    (modifiers
+      (annotation
+        (identifier)
+        (annotation_argument_list
+          (element_value_pair
+            (identifier)
+            (string_literal
+              (string_fragment)))
+          (element_value_pair
+            (semgrep_named_ellipsis)))))
+    (identifier)
+    (class_body)))
+
+================================================================================
+Named ellipsis in @interface body (LANG-469)
+================================================================================
+
+@interface $A { $...ELEMENTS }
+
+--------------------------------------------------------------------------------
+
+(program
+  (annotation_type_declaration
+    (identifier)
+    (annotation_type_body
+      (annotation_type_element_declaration
+        (semgrep_named_ellipsis)))))


### PR DESCRIPTION
## Summary

Augments the Java grammar so several canonical Semgrep patterns parse without ERROR nodes.

Fixes:
- **LANG-466** — `...` (and `$...META`) between arrow-rule entries in `switch_block`. The colon-form arm already supported ellipsis via the existing `statement` augmentation; the arrow-rule arm now does too.
- **LANG-467** — `...` and `$...META` inside the enum-constants list of `enum_body`, plus `$...META` in `enum_body_declarations` (the `...` form was already allowed). A GLR conflict declaration between `enum_body` and `enum_body_declarations` is added to disambiguate a bare ellipsis right after `{`.
- **LANG-469** — `$...META` as an entry in `annotation_argument_list` (via `element_value_pair`) and as an annotation-type element declaration in `@interface` bodies (via `annotation_type_element_declaration`).

## Companion release PR

semgrep/semgrep-java#2

## Test plan

- [x] `make build && make test` from `lang/semgrep-grammars/src/semgrep-java`
- [x] 5 new corpus entries in `test/corpus/semgrep.txt` covering the minimal repros from each ticket
- [x] Spot-checked the additional patterns from the tickets (`switch ($X) { case $A -> $B; ... default -> $C; }`, `enum $E { $A, $B, ...; $T $METHOD(...) { ... } }`, `@$ANN(value = "...", $...PROPS) public $T $METHOD(...) { ... }`) — all parse without ERROR nodes.