### PR TITLE
[python] fix Semgrep pattern parsing for canonical idioms

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-python/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-python/grammar.js
@@ -10,6 +10,12 @@ module.exports = grammar(base_grammar, {
   name: 'python',
 
   conflicts: ($, previous) => previous.concat([
+    // `...` inside a dict literal is ambiguous between a
+    // `semgrep_ellipsis` element (LANG-465) and an `ellipsis` that
+    // would otherwise start a `pair` key. Real Semgrep patterns
+    // never write `... :` as a key, but tree-sitter still needs an
+    // explicit conflict declaration to resolve the lookahead.
+    [$.ellipsis, $.semgrep_ellipsis],
   ]),
 
   /*
@@ -17,28 +23,17 @@ module.exports = grammar(base_grammar, {
      if they're not already part of the base grammar.
   */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
-
-    _expression: ($, previous) => choice(
-      $.semgrep_ellipsis,
-      ...previous.members
-    ),
-  */
     // Metavariables
-
-   // Rather than creating a separate metavariable term
-   // and adding it to identifiers, this instead overrides the
-   // regex that is defined in the original tree-sitter grammar.
-   // this is needed since currently in the original tree-sitter grammar,
-   // identifier is a terminal, and thus can't do
-   // the usual choice/previous shadowing definition.
-
+    //
+    // Rather than creating a separate metavariable term and adding it
+    // to identifiers, this overrides the regex defined in the original
+    // tree-sitter grammar. This is needed because in the upstream
+    // grammar `identifier` is a terminal and cannot use the usual
+    // choice/previous shadowing definition.
     identifier: $ => /\$?[_\p{XID_Start}][_\p{XID_Continue}]*/,
 
     // Allow '...' in the attribute position of a dot-access expression,
     // so that patterns like `a. ... .d` work for matching call chains.
-    // This mirrors the Java grammar's field_access override.
     // PREC.call = 22 in the base Python grammar.
     attribute: $ => prec(22, seq(
       field('object', $.primary_expression),
@@ -46,5 +41,67 @@ module.exports = grammar(base_grammar, {
       field('attribute', choice($.identifier, '...')),
     )),
 
+    // Shared semgrep ellipsis token. Used by parameter lists, match-case
+    // pattern lists, and dictionary literals.
+    semgrep_ellipsis: $ => '...',
+
+    // Variadic metavariable (e.g. `$...ARGS`) used in argument lists.
+    semgrep_ellipsis_metavar: $ => token(/\$\.\.\.[A-Z_][A-Z_0-9]*/),
+
+    // LANG-460: allow `...` in a function's parameter list, so patterns
+    // like `def $F(...): ...` parse cleanly.
+    parameter: ($, previous) => choice(
+      $.semgrep_ellipsis,
+      ...previous.members,
+    ),
+
+    // LANG-461: accept `$...ARGS` as a primary expression. This makes
+    // it usable through any rule that already takes an `expression`,
+    // including `argument_list`.
+    primary_expression: ($, previous) => choice(
+      $.semgrep_ellipsis_metavar,
+      $.typed_metavar,
+      ...previous.members,
+    ),
+
+    // LANG-463: typed metavariable `($X : T)`. The leading identifier
+    // must be a metavariable (start with `$`) to disambiguate from a
+    // regular `parenthesized_expression`. We use a dynamic precedence
+    // bump so the parser prefers `typed_metavar` whenever the inner
+    // identifier is a metavariable.
+    typed_metavar: $ => prec.dynamic(1, seq(
+      '(',
+      $.identifier,
+      ':',
+      field('type', $.type),
+      ')',
+    )),
+
+    // LANG-464: allow `...` as a sub-pattern inside class/list/tuple/
+    // dict patterns of a `match` statement. `case_pattern` is the
+    // shared choice used by every pattern container, so a single
+    // override lights up ellipsis everywhere.
+    case_pattern: ($, previous) => prec(1, choice(
+      $.semgrep_ellipsis,
+      ...previous.content.members,
+    )),
+
+    // LANG-465: allow `...` as an element of a dict literal alongside
+    // `pair` and `dictionary_splat`. The base rule is a `seq(...)`
+    // not a `choice(...)`, so we restate it.
+    dictionary: $ => seq(
+      '{',
+      optional(commaSep1(choice(
+        $.pair,
+        $.dictionary_splat,
+        $.semgrep_ellipsis,
+      ))),
+      optional(','),
+      '}',
+    ),
   }
 });
+
+function commaSep1(rule) {
+  return seq(rule, repeat(seq(',', rule)));
+}

--- a/lang/semgrep-grammars/src/semgrep-python/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-python/test/corpus/semgrep.txt
@@ -39,3 +39,108 @@ Metavariable in match
                   (string_start)
                   (string_content)
                   (string_end))))))))))
+
+====================================
+LANG-460: def with ellipsis params
+====================================
+
+def $F(...): ...
+---
+
+(module
+  (function_definition
+    (identifier)
+    (parameters
+      (semgrep_ellipsis))
+    (block
+      (expression_statement
+        (ellipsis)))))
+
+====================================
+LANG-461: variadic metavariable in argument list
+====================================
+
+foo($...ARGS)
+---
+
+(module
+  (expression_statement
+    (call
+      (identifier)
+      (argument_list
+        (semgrep_ellipsis_metavar)))))
+
+====================================
+LANG-461: variadic metavariable mixed with regular args
+====================================
+
+requests.get($URL, $...REST)
+---
+
+(module
+  (expression_statement
+    (call
+      (attribute
+        (identifier)
+        (identifier))
+      (argument_list
+        (identifier)
+        (semgrep_ellipsis_metavar)))))
+
+====================================
+LANG-463: typed metavariable expression
+====================================
+
+($X : str)
+---
+
+(module
+  (expression_statement
+    (typed_metavar
+      (identifier)
+      (type
+        (identifier)))))
+
+====================================
+LANG-464: ellipsis in match-case class pattern
+====================================
+
+match x:
+    case $CLS($X, ...): ...
+---
+
+(module
+  (match_statement
+    (identifier)
+    (block
+      (case_clause
+        (case_pattern
+          (class_pattern
+            (dotted_name
+              (identifier))
+            (case_pattern
+              (dotted_name
+                (identifier)))
+            (case_pattern
+              (semgrep_ellipsis))))
+        (block
+          (expression_statement
+            (ellipsis)))))))
+
+====================================
+LANG-465: ellipsis in dict literal
+====================================
+
+{"k": 1, ...}
+---
+
+(module
+  (expression_statement
+    (dictionary
+      (pair
+        (string
+          (string_start)
+          (string_content)
+          (string_end))
+        (integer))
+      (semgrep_ellipsis))))


### PR DESCRIPTION
## Summary

Augments the Python tree-sitter grammar so the most common Semgrep pattern idioms parse cleanly. Today each of these produces an `ERROR` node, which causes pattern matching to silently fail.

## Tickets fixed

- [LANG-460](https://linear.app/semgrep/issue/LANG-460) - `...` in a function parameter list (`def $F(...): ...`)
- [LANG-461](https://linear.app/semgrep/issue/LANG-461) - `$...ARGS` variadic metavariable in call argument lists
- [LANG-463](https://linear.app/semgrep/issue/LANG-463) - typed metavariable `($X : T)`
- [LANG-464](https://linear.app/semgrep/issue/LANG-464) - `...` inside `match` / `case` class/list/tuple/dict patterns
- [LANG-465](https://linear.app/semgrep/issue/LANG-465) - `...` as an element of a dict literal

## Tickets deferred

- [LANG-462](https://linear.app/semgrep/issue/LANG-462) - deep ellipsis (labeled `fix:scanner-or-entrypoint`); needs scanner work, tracked separately.

## Approach

- Introduces shared `semgrep_ellipsis` and `semgrep_ellipsis_metavar` terminals, plus a `typed_metavar` rule.
- Extends `parameter`, `primary_expression`, `case_pattern`, and `dictionary` (the last is restated since the base rule is a `seq`, not a `choice`).
- Adds one `[ellipsis, semgrep_ellipsis]` conflict to resolve the 1-lookahead ambiguity between an `ellipsis` pair-key and a `semgrep_ellipsis` element inside a dict literal. (Mentioned in the PR body since this goes slightly beyond the proposed-fix sketch in the tickets.)

## Verification

- `make build` succeeds.
- `make test` passes 123/123 (115 upstream + 2 pre-existing semgrep + 6 new corpus entries, one per fixed ticket plus a mixed `requests.get($URL, $...REST)` case for LANG-461).
- Each minimal repro from the tickets parses with no `ERROR` / `MISSING` nodes (spot-checked with `tree-sitter parse`).
- Sanity-checked that ordinary `(x)` still parses as a `parenthesized_expression`, and ordinary parameter lists / dict literals / match-case patterns are unaffected.

## Test plan

- [ ] CI green
- [ ] After this lands, `./release --branch fix/python-pattern-augmentation python` will push generated artifacts to `semgrep-python` (separate PR will be opened)