### PR TITLE
[swift] fix Semgrep pattern parsing for protocol bodies and inheritance lists

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-swift/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-swift/grammar.js
@@ -71,6 +71,21 @@ module.exports = grammar(base_grammar, {
       $.semgrep_ellipsis,
     ),
 
+    // LANG-499: allow `...` inside `protocol $P { ... }` bodies.
+    _protocol_member_declaration: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    // LANG-503: allow ellipsis / metavariable-ellipsis in inheritance lists,
+    // covering class, struct, extension, enum, and protocol since they all
+    // share `_inheritance_specifiers`.
+    inheritance_specifier: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_ellipsis_metavar,
+    ),
+
     type_parameter: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis,

--- a/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-swift/test/corpus/semgrep.txt
@@ -282,6 +282,94 @@ foo
   (fully_open_range))
 
 ================================================================================
+Protocol Body Ellipsis
+================================================================================
+
+protocol $P {
+  ...
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (protocol_declaration
+    (type_identifier)
+    (protocol_body
+      (semgrep_ellipsis))))
+
+================================================================================
+Protocol Body Ellipsis Sandwiched
+================================================================================
+
+protocol $P {
+  ...
+  func foo()
+  ...
+}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (protocol_declaration
+    (type_identifier)
+    (protocol_body
+      (semgrep_ellipsis)
+      (protocol_function_declaration
+        (simple_identifier))
+      (semgrep_ellipsis))))
+
+================================================================================
+Class Inheritance Ellipsis
+================================================================================
+
+class $C: $P, ... {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (inheritance_specifier
+      (semgrep_ellipsis))
+    (class_body)))
+
+================================================================================
+Class Inheritance Metavariable Ellipsis
+================================================================================
+
+class $C: $...PROTOS {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (inheritance_specifier
+      (semgrep_ellipsis_metavar))
+    (class_body)))
+
+================================================================================
+Protocol Inheritance Ellipsis
+================================================================================
+
+protocol $P: $Q, ... {}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (protocol_declaration
+    (type_identifier)
+    (inheritance_specifier
+      (user_type
+        (type_identifier)))
+    (inheritance_specifier
+      (semgrep_ellipsis))
+    (protocol_body)))
+
+================================================================================
 Field Access with Ellipsis
 ================================================================================
 


### PR DESCRIPTION
## Summary

Extends `semgrep-swift` to allow semgrep ellipses in two places that previously produced ERROR nodes:

- **LANG-499** (`protocol $P { ... }`): overrides `_protocol_member_declaration` to accept `$.semgrep_ellipsis`. Mirrors the existing `_type_level_declaration` extension; the latter only covers class/struct/enum bodies because protocol bodies use a separate rule chain in the base grammar.
- **LANG-503** (`class $C: $P, ... {}` and `class $C: $...PROTOS {}`): overrides `inheritance_specifier` to accept `$.semgrep_ellipsis` and `$.semgrep_ellipsis_metavar`. Class, struct, extension, enum, and protocol declarations all share `_inheritance_specifiers`, so a single override covers all five.

Linear: [LANG-499](https://linear.app/semgrep/issue/LANG-499), [LANG-503](https://linear.app/semgrep/issue/LANG-503)
Release PR: semgrep/semgrep-swift#1

## Test plan

- [x] `make build && make test` in `lang/semgrep-grammars/src/semgrep-swift` (200/200 corpus tests pass)
- [x] Spot-checked all three patterns parse without ERROR nodes:
  - `protocol $P { ... }` -> `(protocol_body (semgrep_ellipsis))`
  - `class $C: $P, ... {}` -> two `(inheritance_specifier ...)` siblings, second wrapping `(semgrep_ellipsis)`
  - `class $C: $...PROTOS {}` -> `(inheritance_specifier (semgrep_ellipsis_metavar))`
- [x] Added 5 new corpus tests (protocol body ellipsis, sandwiched, class inheritance ellipsis, metavar ellipsis, protocol inheritance ellipsis)

After this PR is merged, follow up with a release of `semgrep-swift`.