### PR TITLE
[go] add Semgrep grammar augmentation (was empty)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-go/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-go/grammar.js
@@ -1,7 +1,15 @@
 /*
   semgrep-go
 
-  Extends the standard go grammar with semgrep pattern constructs.
+  Extends the standard go grammar with semgrep pattern constructs:
+    - '...'           ellipsis
+    - '$X'            metavariable
+    - '$...X'         ellipsis-metavariable
+    - '<... e ...>'   deep ellipsis
+
+  Go identifiers cannot contain '$', so we introduce an explicit
+  semgrep_metavariable token (similar to how semgrep-kotlin overrides
+  simple_identifier).
 */
 
 const base_grammar = require('tree-sitter-go/grammar');
@@ -10,22 +18,99 @@ module.exports = grammar(base_grammar, {
   name: 'go',
 
   conflicts: ($, previous) => previous.concat([
+    // Allow GLR exploration when '...' could parse as either an
+    // expression-position ellipsis or a statement-position ellipsis.
+    [$._expression, $._statement],
+    // 'Foo{...}' — '...' could be an expression literal_element or
+    // the explicit ellipsis literal_element alternative.
+    [$._expression, $.literal_element],
   ]),
 
-  /*
-     Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
-     if they're not already part of the base grammar.
-  */
   rules: {
-  /*
     semgrep_ellipsis: $ => '...',
+    semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
+    semgrep_ellipsis_metavar: $ => token(/\$\.\.\.[A-Z_][A-Z_0-9]*/),
+    semgrep_deep_expression: $ => seq('<...', $._expression, '...>'),
 
-    _expression: ($, previous) => {
-      return choice(
-        $.semgrep_ellipsis,
-        ...previous.members
-      );
-    }
-  */
+    // Allow '$X', '...', '$...X', '<... e ...>' anywhere an expression
+    // is allowed. Covers '$F(...)', '$OBJ.$M(...)', etc.
+    _expression: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_metavariable,
+      $.semgrep_ellipsis_metavar,
+      $.semgrep_deep_expression,
+    ),
+
+    // Allow a bare '...' or '$...X' between statements.
+    _statement: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_ellipsis_metavar,
+    ),
+
+    // 'func $F($X int, ...)' — accept '...', '$...REST', or a typed
+    // metavariable parameter ('$X int'), in addition to upstream forms.
+    parameter_declaration: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_ellipsis_metavar,
+      seq(
+        field('name', $.semgrep_metavariable),
+        field('type', $._type),
+      ),
+    ),
+
+    // Composite-literal bodies: 'Foo{$X: $Y, ...}', 'map[string]$T{...}',
+    // '[]$T{ $X, ..., $Y }'.
+    literal_element: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    // Struct bodies: 'struct { $F $T; ... }'.
+    field_declaration: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    // Interface bodies: 'interface { $M(...) $T; ... }'.
+    method_spec: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    // Selector field and struct field name: '$OBJ.$M(...)',
+    // 'struct { $F int }'. _field_identifier is an alias of identifier
+    // upstream; override it to also accept a metavariable.
+    _field_identifier: $ => choice(
+      alias($.identifier, $.field_identifier),
+      $.semgrep_metavariable,
+    ),
+
+    // Type metavariable: 'map[string]$T', '[]$T', etc.
+    _type_identifier: $ => choice(
+      alias($.identifier, $.type_identifier),
+      $.semgrep_metavariable,
+    ),
+
+    // Disambiguate '[...]T' (implicit-length array) from
+    // '[' semgrep_ellipsis ']' indexing.
+    implicit_length_array_type: $ => prec(1, seq(
+      '[',
+      '...',
+      ']',
+      field('element', $._type),
+    )),
+
+    // 'func $F(...)' — allow a metavariable as the function name.
+    function_declaration: $ => prec.right(1, seq(
+      'func',
+      field('name', choice($.identifier, $.semgrep_metavariable)),
+      field('type_parameters', optional($.type_parameter_list)),
+      field('parameters', $.parameter_list),
+      field('result', optional(choice($.parameter_list, $._simple_type))),
+      field('body', optional($.block)),
+    )),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-go/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-go/test/corpus/semgrep.txt
@@ -1,0 +1,258 @@
+================================================================================
+Bare metavariable
+================================================================================
+
+$X
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_metavariable))
+
+================================================================================
+Bare ellipsis
+================================================================================
+
+...
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_ellipsis))
+
+================================================================================
+Ellipsis-metavariable
+================================================================================
+
+$...ARGS
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_ellipsis_metavar))
+
+================================================================================
+Call with ellipsis args
+================================================================================
+
+$F(...)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (call_expression
+    function: (semgrep_metavariable)
+    arguments: (argument_list
+      (semgrep_ellipsis))))
+
+================================================================================
+Method call on metavariable receiver
+================================================================================
+
+$OBJ.$M(...)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (call_expression
+    function: (selector_expression
+      operand: (semgrep_metavariable)
+      field: (semgrep_metavariable))
+    arguments: (argument_list
+      (semgrep_ellipsis))))
+
+================================================================================
+Goroutine with metavariable
+================================================================================
+
+go $F(...)
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (go_statement
+    (call_expression
+      function: (semgrep_metavariable)
+      arguments: (argument_list
+        (semgrep_ellipsis)))))
+
+================================================================================
+If err with statement ellipsis
+================================================================================
+
+package p
+func f() { if err != nil { ... } }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (function_declaration
+    name: (identifier)
+    parameters: (parameter_list)
+    body: (block
+      (if_statement
+        condition: (binary_expression
+          left: (identifier)
+          right: (nil))
+        consequence: (block
+          (semgrep_ellipsis))))))
+
+================================================================================
+Deep ellipsis
+================================================================================
+
+<... $X ...>
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_deep_expression
+    (semgrep_metavariable)))
+
+================================================================================
+Composite literal with keyed metavariable and ellipsis
+================================================================================
+
+package p
+var _ = Foo{a: b, ...}
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (var_declaration
+    (var_spec
+      name: (identifier)
+      value: (expression_list
+        (composite_literal
+          type: (type_identifier)
+          body: (literal_value
+            (keyed_element
+              (literal_element
+                (identifier))
+              (literal_element
+                (identifier)))
+            (literal_element
+              (semgrep_ellipsis))))))))
+
+================================================================================
+Map literal with metavariable value type
+================================================================================
+
+package p
+var _ = map[string]$T{ ... }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (var_declaration
+    (var_spec
+      name: (identifier)
+      value: (expression_list
+        (composite_literal
+          type: (map_type
+            key: (type_identifier)
+            value: (semgrep_metavariable))
+          body: (literal_value
+            (literal_element
+              (semgrep_ellipsis))))))))
+
+================================================================================
+Slice literal with bookend metavariables
+================================================================================
+
+package p
+var _ = []$T{ $X, ..., $Y }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (var_declaration
+    (var_spec
+      name: (identifier)
+      value: (expression_list
+        (composite_literal
+          type: (slice_type
+            element: (semgrep_metavariable))
+          body: (literal_value
+            (literal_element
+              (semgrep_metavariable))
+            (literal_element
+              (semgrep_ellipsis))
+            (literal_element
+              (semgrep_metavariable))))))))
+
+================================================================================
+Struct with metavariable field plus ellipsis
+================================================================================
+
+package p
+type S struct { $F $T; ... }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (type_declaration
+    (type_spec
+      name: (type_identifier)
+      type: (struct_type
+        (field_declaration_list
+          (field_declaration
+            name: (semgrep_metavariable)
+            type: (semgrep_metavariable))
+          (field_declaration
+            (semgrep_ellipsis)))))))
+
+================================================================================
+Interface with metavariable method plus ellipsis
+================================================================================
+
+package p
+type I interface { $M(...) $T; ... }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (type_declaration
+    (type_spec
+      name: (type_identifier)
+      type: (interface_type
+        (method_spec
+          name: (semgrep_metavariable)
+          parameters: (parameter_list
+            (parameter_declaration
+              (semgrep_ellipsis)))
+          result: (semgrep_metavariable))
+        (method_spec
+          (semgrep_ellipsis))))))
+
+================================================================================
+Function with ellipsis parameter
+================================================================================
+
+package p
+func $F(...) { ... }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (package_clause
+    (package_identifier))
+  (function_declaration
+    name: (semgrep_metavariable)
+    parameters: (parameter_list
+      (parameter_declaration
+        (semgrep_ellipsis)))
+    body: (block
+      (semgrep_ellipsis))))


### PR DESCRIPTION
## Summary

The semgrep-go augmentation file (`lang/semgrep-grammars/src/semgrep-go/grammar.js`) had its `rules` block entirely commented out, so the augmented Go parser was identical to upstream tree-sitter-go and rejected every Semgrep pattern construct (an automated audit found 25/25 patterns broken). This PR builds the augmentation from scratch.

Tickets:
- **LANG-468** (umbrella): entire augmentation needed — `$X`, `...`, `$...X`, `<... e ...>` not recognized.
- **LANG-470**: deep ellipsis `<... $X ...>`.
- **LANG-472**: ellipsis in composite literal elements, struct field declarations, interface method specs.

## Changes

New rules:
- `semgrep_ellipsis` (`...`)
- `semgrep_metavariable` (`$X`) — Go identifiers cannot contain `$`, so we need an explicit token (similar to how semgrep-kotlin handles `simple_identifier`)
- `semgrep_ellipsis_metavar` (`$...X`)
- `semgrep_deep_expression` (`<... e ...>`)

Wired into upstream productions:
- `_expression` — gates `$X`, `...`, `$...X`, `<... e ...>` anywhere an expression is allowed
- `_statement` — bare `...` and `$...X` between statements
- `parameter_declaration` — `func $F(...)`, `func $F($X int, $...REST)`
- `literal_element` — `Foo{$X: $Y, ...}`, `map[string]$T{...}`, `[]$T{ $X, ..., $Y }`
- `field_declaration` — `struct { $F $T; ... }`
- `method_spec` — `interface { $M(...) $T; ... }`
- `_field_identifier` — `$OBJ.$M(...)`, `struct { $F int }`
- `_type_identifier` — `map[string]$T`, `[]$T`
- `function_declaration` — `func $F(...) { ... }`
- `implicit_length_array_type` (precedence bump) — keep `[...]T` unambiguous

Conflict additions for the new GLR ambiguities introduced.

## Test plan

- [x] `make build` succeeds (tree-sitter generates the augmented parser)
- [x] `make test` — 80 tests pass (66 upstream + 14 new semgrep corpus tests)
- [x] Spot-checks for all minimal repros in LANG-468/470/472 produce no `(ERROR ...)` nodes

🤖 Generated with [Claude Code](https://claude.com/claude-code)