### PR TITLE
[rust] fix Semgrep pattern parsing for tuple_pattern, use_list, and struct expression rest

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-rust/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-rust/grammar.js
@@ -73,6 +73,37 @@ module.exports = grammar(standard_grammar, {
       );
     },
 
+    // Allow Semgrep ellipsis inside tuple patterns: `let ($X, ...) = $E;`
+    tuple_pattern: ($, previous) => seq(
+      '(',
+      sepBy(',', choice($._pattern, $.closure_expression, $.ellipsis)),
+      optional(','),
+      ')',
+    ),
+
+    // Allow Semgrep ellipsis inside use lists: `use foo::{...};`
+    use_list: ($, previous) => seq(
+      '{',
+      sepBy(',', choice($._use_clause, $.ellipsis)),
+      optional(','),
+      '}',
+    ),
+
+    // Allow Semgrep ellipsis and bare `..` rest in struct expressions:
+    //   `Foo { x: 1, ... }` and `Foo { x, .. }`.
+    field_initializer_list: ($, previous) => seq(
+      '{',
+      sepBy(',', choice(
+        $.shorthand_field_initializer,
+        $.field_initializer,
+        $.base_field_initializer,
+        $.ellipsis,
+        '..',
+      )),
+      optional(','),
+      '}',
+    ),
+
     // Expression ellipsis
     _expression: ($, previous) => {
       return choice(

--- a/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-rust/test/corpus/semgrep.txt
@@ -328,3 +328,93 @@ $...X;
 (source_file
   (expression_statement
     (identifier)))
+
+================================================================================
+Ellipsis in tuple pattern
+================================================================================
+
+__SEMGREP_STATEMENT
+let ($X, ...) = e;
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_statement
+    (let_declaration
+      (tuple_pattern
+        (identifier)
+        (ellipsis))
+      (identifier))))
+
+================================================================================
+Ellipsis in use list
+================================================================================
+
+use foo::{...};
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (use_declaration
+    (scoped_use_list
+      (identifier)
+      (use_list
+        (ellipsis)))))
+
+================================================================================
+Bare rest in struct expression
+================================================================================
+
+__SEMGREP_EXPRESSION
+Foo { x, .. }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_expression
+    (struct_expression
+      (type_identifier)
+      (field_initializer_list
+        (shorthand_field_initializer
+          (identifier))))))
+
+================================================================================
+Ellipsis in struct expression
+================================================================================
+
+__SEMGREP_EXPRESSION
+Foo { x: 1, ... }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_expression
+    (struct_expression
+      (type_identifier)
+      (field_initializer_list
+        (field_initializer
+          (field_identifier)
+          (integer_literal))
+        (ellipsis)))))
+
+================================================================================
+Nested struct expression with rest
+================================================================================
+
+__SEMGREP_EXPRESSION
+Foo { bar: Baz { x, .. }, .. }
+
+--------------------------------------------------------------------------------
+
+(source_file
+  (semgrep_expression
+    (struct_expression
+      (type_identifier)
+      (field_initializer_list
+        (field_initializer
+          (field_identifier)
+          (struct_expression
+            (type_identifier)
+            (field_initializer_list
+              (shorthand_field_initializer
+                (identifier)))))))))


### PR DESCRIPTION
## Summary

Augments `lang/semgrep-grammars/src/semgrep-rust/grammar.js` so three previously-broken Semgrep idioms parse cleanly:

- **LANG-479** ([link](https://linear.app/semgrep/issue/LANG-479)): `tuple_pattern` and `use_list` now accept `$.ellipsis`, so patterns like `let ($X, ...) = $E;` and `use $P::{...};` parse without error nodes.
- **LANG-495** ([link](https://linear.app/semgrep/issue/LANG-495)): `field_initializer_list` is widened in place to accept `$.ellipsis` (Semgrep `...`) and a bare `..` rest marker, so `Foo { x: 1, ... }` and `Foo { x, .. }` (which base Rust rejects) parse as struct expressions.

The augmentations follow the existing in-place precedent (`field_declaration`, `_declaration_statement`). No top-level `conflicts` entry was needed.

Companion release PR: https://github.com/semgrep/semgrep-rust/pull/2

## Tickets deferred

- **LANG-487** — adding a standalone-type entry point is `fix:scanner-or-entrypoint`: it needs a new `__SEMGREP_TYPE` rule plus OCaml-side plumbing in semgrep-core's Rust mapper. Out of scope for an augmentation-only PR.

## Test plan

- [x] `make build && make test` in `lang/semgrep-grammars/src/semgrep-rust/` — all 169 corpus tests pass, including 5 new ones:
  - `Ellipsis in tuple pattern` — `let ($X, ...) = e;`
  - `Ellipsis in use list` — `use foo::{...};`
  - `Bare rest in struct expression` — `Foo { x, .. }`
  - `Ellipsis in struct expression` — `Foo { x: 1, ... }`
  - `Nested struct expression with rest` — `Foo { bar: Baz { x, .. }, .. }`
- [ ] Companion release PR merged: https://github.com/semgrep/semgrep-rust/pull/2
- [ ] Confirm semgrep-core's Rust mapper handles the new tokens (bare `..` and ellipsis in `field_initializer_list`) without crashing — flagged in LANG-495 as a possible follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)