### PR TITLE
[cpp] fix Semgrep pattern parsing for class/struct/enum bodies and operator overloads

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-cpp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-cpp/grammar.js
@@ -33,7 +33,10 @@ module.exports = grammar(base_grammar, {
 
     // Typed metavariables
 
-    semgrep_metavar: $ => /\$[A-Z_][A-Z_0-9]*/,
+    // Token precedence so the lexer prefers `semgrep_metavar` over the
+    // `identifier` rule (whose regex also accepts a leading `$`) when
+    // the surrounding rule allows a metavar (e.g. inside an enum body).
+    semgrep_metavar: $ => token(prec(1, /\$[A-Z_][A-Z_0-9]*/)),
 
     semgrep_typed_metavar: $ =>
       seq(
@@ -97,6 +100,50 @@ module.exports = grammar(base_grammar, {
     _field_identifier: ($, previous) => choice(
       previous,
       $.semgrep_ellipsis
+    ),
+
+    // Allow `...` and `$X` inside class/struct bodies, e.g.
+    //   class C { ... }
+    //   struct S { $X }
+    // The lexer prefers `semgrep_metavar` over `identifier` thanks to
+    // the token precedence on `semgrep_metavar`, so a bare `$X` ends
+    // up here rather than as a malformed field_declaration.
+    _field_declaration_list_item: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_metavar
+    ),
+
+    // Allow `...` and `$X` inside enum bodies, e.g.
+    //   enum E { ... }
+    // The upstream rule is a `seq` so we must override it wholesale
+    // (copied from tree-sitter-c with semgrep alternatives added).
+    enumerator_list: $ => seq(
+      '{',
+      repeat(choice(
+        seq($.enumerator, ','),
+        alias($.preproc_if_in_enumerator_list, $.preproc_if),
+        alias($.preproc_ifdef_in_enumerator_list, $.preproc_ifdef),
+        seq($.preproc_call, ','),
+        seq($.semgrep_ellipsis, ','),
+        seq($.semgrep_metavar, ','),
+      )),
+      optional(choice(
+        $.enumerator,
+        alias($.preproc_if_in_enumerator_list_no_comma, $.preproc_if),
+        alias($.preproc_ifdef_in_enumerator_list_no_comma, $.preproc_ifdef),
+        $.preproc_call,
+        $.semgrep_ellipsis,
+        $.semgrep_metavar,
+      )),
+      '}',
+    ),
+
+    // Allow `operator $OP` as an operator name, e.g.
+    //   T operator $OP(T x);
+    operator_name: ($, previous) => choice(
+      previous,
+      prec(1, seq('operator', $.semgrep_metavar)),
     ),
 
     // So we prefer to parse a unary left fold for

--- a/lang/semgrep-grammars/src/semgrep-cpp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-cpp/test/corpus/semgrep.txt
@@ -294,3 +294,95 @@ int x = (x * $Y);
             (type_identifier)
             (abstract_pointer_declarator))
           (semgrep_metavar))))))
+
+================================================================================
+Class body ellipsis
+================================================================================
+
+class $C { ... };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (class_specifier
+    (type_identifier)
+    (field_declaration_list
+      (semgrep_ellipsis))))
+
+================================================================================
+Struct body ellipsis
+================================================================================
+
+struct $S { ... };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (struct_specifier
+    (type_identifier)
+    (field_declaration_list
+      (semgrep_ellipsis))))
+
+================================================================================
+Struct body metavar
+================================================================================
+
+struct $S { $X };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (struct_specifier
+    (type_identifier)
+    (field_declaration_list
+      (semgrep_metavar))))
+
+================================================================================
+Enum body ellipsis
+================================================================================
+
+enum $E { ... };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (enum_specifier
+    (type_identifier)
+    (enumerator_list
+      (semgrep_ellipsis))))
+
+================================================================================
+Enum body metavar
+================================================================================
+
+enum $E { $X };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (enum_specifier
+    (type_identifier)
+    (enumerator_list
+      (semgrep_metavar))))
+
+================================================================================
+Operator name metavar
+================================================================================
+
+class C { T operator $OP(T x); };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (class_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (type_identifier)
+        (function_declarator
+          (operator_name
+            (semgrep_metavar))
+          (parameter_list
+            (parameter_declaration
+              (type_identifier)
+              (identifier))))))))


### PR DESCRIPTION
## Summary

Augments the C++ grammar so canonical Semgrep patterns parse cleanly:

- **LANG-486**: `...` and `$X` inside class/struct bodies (via `_field_declaration_list_item`) and enum bodies (via a wholesale override of `enumerator_list`, since the upstream rule is a `seq`).
- **LANG-497**: `operator $OP` as an operator name (via a `previous`-style augmentation of `operator_name`).

The `semgrep_metavar` token gets a precedence bump so the lexer prefers it over `identifier` (whose regex also accepts a leading `$`) when both are valid at a position; this is what lets a bare `$X` parse as a metavariable inside enum/struct bodies instead of as a malformed declaration or enumerator.

Companion release PR: semgrep/semgrep-cpp#2

## Test plan

- [x] `make build && make test` (all 201 corpus tests pass, including 6 new ones)
- [x] Spot-checked `class $C { ... };`, `struct $S { $X };`, `enum $E { ... };`, `class C { T operator $OP(T x); };`

Tickets: LANG-486, LANG-497

Generated with [Claude Code](https://claude.com/claude-code)