### PR TITLE
[kotlin] fix Semgrep pattern parsing for class/when/enum class bodies

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-kotlin/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-kotlin/grammar.js
@@ -60,6 +60,35 @@ module.exports = grammar(standard_grammar, {
       return choice(previous, $.ellipsis);
     },
 
+    // Allow single-line `class Foo { ... }` patterns. Without this,
+    // a bare ellipsis between `{` and `}` fails because class members
+    // require trailing `semis` (see LANG-476).
+    class_body: ($, previous) => {
+      return choice(previous, seq("{", $.ellipsis, "}"));
+    },
+
+    // Same as `class_body`, for `enum class E { ... }` (LANG-483).
+    // Higher prec so `enum class E { ... }` resolves to the dedicated
+    // single-line alternative rather than the multi-line form with a
+    // single `enum_entry` of ellipsis.
+    enum_class_body: ($, previous) => {
+      return choice(previous, prec(1, seq("{", $.ellipsis, "}")));
+    },
+
+    // Allow `...` as a stand-alone enum entry, for multi-line forms
+    // like `enum class E { A, B, ... }` (LANG-483).
+    enum_entry: ($, previous) => {
+      return choice(previous, $.ellipsis);
+    },
+
+    // Allow `...` as a `when` body entry: `when ($X) { ... }` (LANG-480).
+    // Higher prec than `_expression`'s ellipsis so a bare `...` in a
+    // `when` body parses as a stand-alone entry rather than the start
+    // of an expression-form `when_condition`.
+    when_entry: ($, previous) => {
+      return choice(previous, prec(1, $.ellipsis));
+    },
+
     deep_ellipsis: ($) => seq("<...", $._expression, "...>"),
 
     ellipsis: ($) => "...",

--- a/lang/semgrep-grammars/src/semgrep-kotlin/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-kotlin/test/corpus/semgrep.txt
@@ -389,3 +389,172 @@ class Foo
 (source_file
   (class_declaration
     (type_identifier)))
+
+=====================================
+Single-line class body ellipsis
+=====================================
+
+class Foo { ... }
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (ellipsis))))
+
+=====================================
+Single-line interface body ellipsis
+=====================================
+
+interface I { ... }
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (class_body
+      (ellipsis))))
+
+=====================================
+Single-line object body ellipsis with delegation
+=====================================
+
+object O : T { ... }
+
+---
+
+(source_file
+  (object_declaration
+    (type_identifier)
+    (delegation_specifier
+      (user_type
+        (type_identifier)))
+    (class_body
+      (ellipsis))))
+
+=====================================
+Annotation class single-line body ellipsis
+=====================================
+
+annotation class A { ... }
+
+---
+
+(source_file
+  (class_declaration
+    (modifiers
+      (class_modifier))
+    (type_identifier)
+    (class_body
+      (ellipsis))))
+
+=====================================
+Enum class single-line body ellipsis
+=====================================
+
+enum class E { ... }
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (enum_class_body
+      (ellipsis))))
+
+=====================================
+Enum class multi-line entry ellipsis
+=====================================
+
+enum class E {
+  A,
+  B,
+  ...
+}
+
+---
+
+(source_file
+  (class_declaration
+    (type_identifier)
+    (enum_class_body
+      (enum_entry
+        (simple_identifier))
+      (enum_entry
+        (simple_identifier))
+      (enum_entry
+        (ellipsis)))))
+
+=====================================
+When expression single-line ellipsis
+=====================================
+
+fun foo() {
+  when (x) { ... }
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (when_expression
+          (when_subject
+            (simple_identifier))
+          (when_entry
+            (ellipsis)))))))
+
+=====================================
+When expression with branch and ellipsis
+=====================================
+
+fun foo() {
+  when (x) {
+    a -> b
+    ...
+  }
+}
+
+---
+
+(source_file
+  (function_declaration
+    (simple_identifier)
+    (function_value_parameters)
+    (function_body
+      (statements
+        (when_expression
+          (when_subject
+            (simple_identifier))
+          (when_entry
+            (when_condition
+              (simple_identifier))
+            (control_structure_body
+              (simple_identifier)))
+          (when_entry
+            (ellipsis)))))))
+
+=====================================
+When expression as assignment value
+=====================================
+
+val x = when (y) { ... }
+
+---
+
+(source_file
+  (property_declaration
+    (binding_pattern_kind)
+    (variable_declaration
+      (simple_identifier))
+    (when_expression
+      (when_subject
+        (simple_identifier))
+      (when_entry
+        (ellipsis)))))


### PR DESCRIPTION
## Summary

Augments the Kotlin Semgrep grammar so common Semgrep pattern idioms parse cleanly:

- **LANG-476** — Single-line `class Foo { ... }` (also `interface`, `object`, generic, annotation, and annotated class forms): adds a `seq("{", ellipsis, "}")` alternative on `class_body`, bypassing the `semis`-separator requirement that previously rejected a bare ellipsis between `{` and `}`.
- **LANG-480** — `when ($X) { ... }`: augments `when_entry` to accept a bare ellipsis (with prec=1 over expression-form ellipsis), covering lone `...`, trailing `...` after a real entry, and `val x = when(y) { ... }`.
- **LANG-483** — `enum class E { ... }`: mirrors the `class_body` fix on `enum_class_body`, plus extends `enum_entry` to accept `...` so multi-line `enum class E { A, B, ... }` works.

Linear: LANG-476, LANG-480, LANG-483.
Companion semgrep-kotlin release PR: semgrep/semgrep-kotlin#1

## Test plan

- [x] `make test` in `lang/semgrep-grammars/src/semgrep-kotlin` passes (all 316 tests including 9 new corpus tests).
- [ ] Reviewer confirms the new corpus entries in `test/corpus/semgrep.txt` mirror the patterns called out in the linked tickets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)