### PR TITLE
[php] add Semgrep grammar augmentation (was empty)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-php/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-php/grammar.js
@@ -2,6 +2,21 @@
   semgrep-php
 
   Extends the standard php grammar with semgrep pattern constructs.
+
+  Notes on the lexer interaction with PHP variables:
+  - PHP variables natively start with `$` (e.g. `$foo`), so a metavariable
+    such as `$FOO` already parses as a `variable_name`. We do NOT need to
+    introduce a separate metavariable-as-variable token.
+  - For metavariables in identifier positions (class names, function names,
+    type names, etc.) we use `semgrep_metavar_ident`, a token that looks like
+    `$FOO` but matches uppercase metavariable convention. Since `$FOO` would
+    otherwise lex as `$` + `name`, we use a higher-precedence token. In
+    identifier positions a `variable_name` is not legal, so there is no
+    ambiguity.
+  - PHP's variable-variable syntax `$$F` lexes naturally as `$` + `$F`, where
+    `$F` is a `variable_name`. We rely on `semgrep_metavar_ident` only being
+    accepted in identifier positions, not variable positions, so `$$FOO` keeps
+    its variable-variable meaning.
 */
 
 const base_grammar = require('tree-sitter-php/grammar');
@@ -10,22 +25,221 @@ module.exports = grammar(base_grammar, {
   name: 'php',
 
   conflicts: ($, previous) => previous.concat([
+    // semgrep_ellipsis as expression vs as statement: a bare `...` can be
+    // either an `expression_statement` (when followed by `;`) or a
+    // standalone `semgrep_ellipsis` statement.
+    [$._expression, $.program],
+    [$._expression, $.compound_statement],
+    [$._expression, $.while_statement],
+    [$._expression, $.if_statement],
+    [$._expression, $.foreach_statement],
+    [$._expression, $.else_clause],
+    [$._expression, $.else_if_clause],
+    [$._expression, $.colon_block],
+    [$._expression, $.default_statement],
+    [$._expression, $.declare_statement],
+    [$._expression, $.match_block],
+    [$._expression, $.for_statement],
   ]),
 
-  /*
-     Support for semgrep ellipsis ('...') and metavariables ('$FOO'),
-     if they're not already part of the base grammar.
-  */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
+    /*
+       Semgrep tokens
+    */
 
-    _expression: ($, previous) => {
-      return choice(
+    // A bare ellipsis. PHP already uses `...` for variadic parameters and
+    // unpacking; we keep those rules untouched and prefer the native
+    // interpretations by giving `semgrep_ellipsis` a negative precedence.
+    semgrep_ellipsis: $ => prec(-1, '...'),
+
+    // `<... expr ...>` - matches an expression "deeply" inside another.
+    semgrep_deep_ellipsis: $ => seq('<...', $._expression, '...>'),
+
+    // `$...ARGS` - matches a sequence of arguments / parameters.
+    semgrep_variadic_metavariable: $ => /\$\.\.\.[A-Z_][A-Z_0-9]*/,
+
+    // `$FOO` used in identifier positions (class / function / type / attribute
+    // name). This is given a higher token precedence than the default
+    // `$` + `name` decomposition so it lexes as a single token, but it is only
+    // accepted in places where an identifier (not a variable) is expected, so
+    // it does not collide with `variable_name`.
+    semgrep_metavar_ident: $ => token(prec(1, /\$[A-Z_][A-Z_0-9]*/)),
+
+    // Convenience: a `name` or a metavariable used as an identifier.
+    _semgrep_extended_name: $ => choice($.name, $.semgrep_metavar_ident),
+
+    /*
+       Wire ellipsis into expression and statement positions
+    */
+
+    _expression: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_deep_ellipsis,
+    ),
+
+    _statement: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    // Allow `...` inside class / interface / trait bodies.
+    _member_declaration: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    // Allow `...` inside enum bodies.
+    _enum_member_declaration: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+    ),
+
+    // Allow `...` and `$...ARGS` as a parameter.
+    formal_parameters: $ => seq(
+      '(',
+      commaSep(choice(
+        $.simple_parameter,
+        $.variadic_parameter,
+        $.property_promotion_parameter,
         $.semgrep_ellipsis,
-        ...previous.members
-      );
-    }
-  */
+        $.semgrep_variadic_metavariable,
+      )),
+      optional(','),
+      ')'
+    ),
+
+    // Allow `$...ARGS` as a function-call argument. `...` (semgrep_ellipsis)
+    // already matches inside expressions so it works as an argument too.
+    argument: ($, previous) => choice(
+      previous,
+      $.semgrep_variadic_metavariable,
+    ),
+
+    // Allow `...` as a match arm. We use `prec.dynamic` to prefer treating a
+    // standalone `...` as a top-level match arm rather than as the start of a
+    // `match_condition_list`.
+    match_block: $ => prec.left(seq(
+      '{',
+      commaSep1(choice(
+        $.match_conditional_expression,
+        $.match_default_expression,
+        prec.dynamic(1, $.semgrep_ellipsis),
+      )),
+      optional(','),
+      '}'
+    )),
+
+    // Allow ellipsis inside attribute argument lists. `arguments` is the
+    // generic call-arguments rule, which is already covered above via
+    // `argument` and the expression-level ellipsis. Nothing extra needed.
+
+    /*
+       Wire metavariable-as-identifier into name positions
+    */
+
+    class_declaration: $ => prec.right(seq(
+      optional(field('attributes', $.attribute_list)),
+      optional(field('modifier', choice($.final_modifier, $.abstract_modifier))),
+      keyword('class'),
+      field('name', $._semgrep_extended_name),
+      optional($.base_clause),
+      optional($.class_interface_clause),
+      field('body', $.declaration_list),
+      optional($._semicolon)
+    )),
+
+    interface_declaration: $ => seq(
+      keyword('interface'),
+      field('name', $._semgrep_extended_name),
+      optional($.base_clause),
+      field('body', $.declaration_list)
+    ),
+
+    trait_declaration: $ => seq(
+      keyword('trait'),
+      field('name', $._semgrep_extended_name),
+      field('body', $.declaration_list)
+    ),
+
+    enum_declaration: $ => prec.right(seq(
+      optional(field('attributes', $.attribute_list)),
+      keyword('enum'),
+      field('name', $._semgrep_extended_name),
+      optional(seq(':', $._type)),
+      optional($.class_interface_clause),
+      field('body', $.enum_declaration_list)
+    )),
+
+    _function_definition_header: $ => seq(
+      keyword('function'),
+      optional('&'),
+      field('name', choice(
+        $.name,
+        alias($._reserved_identifier, $.name),
+        $.semgrep_metavar_ident,
+      )),
+      field('parameters', $.formal_parameters),
+      optional($._return_type)
+    ),
+
+    // Type names (used in parameter types, return types, etc.).
+    named_type: $ => choice(
+      $.name,
+      $.qualified_name,
+      $.semgrep_metavar_ident,
+    ),
+
+    // `extends` / `implements`: allow metavar in the base list.
+    base_clause: $ => seq(
+      keyword('extends'),
+      commaSep1(choice(
+        $.name,
+        alias($._reserved_identifier, $.name),
+        $.qualified_name,
+        $.semgrep_metavar_ident,
+      ))
+    ),
+
+    class_interface_clause: $ => seq(
+      keyword('implements'),
+      commaSep1(choice(
+        $.name,
+        alias($._reserved_identifier, $.name),
+        $.qualified_name,
+        $.semgrep_metavar_ident,
+      ))
+    ),
+
+    // Attribute names.
+    attribute: $ => seq(
+      choice(
+        $.name,
+        alias($._reserved_identifier, $.name),
+        $.qualified_name,
+        $.semgrep_metavar_ident,
+      ),
+      optional(field('parameters', $.arguments))
+    ),
   }
 });
+
+function commaSep1(rule) {
+  return seq(rule, repeat(seq(',', rule)));
+}
+
+function commaSep(rule) {
+  return optional(commaSep1(rule));
+}
+
+// Mirrors the helper in tree-sitter-php's grammar.js so we can re-declare
+// rules that use case-insensitive keywords.
+function keyword(word, aliasAsWord = true) {
+  let pattern = '';
+  for (const letter of word) {
+    pattern += `[${letter}${letter.toLocaleUpperCase()}]`;
+  }
+  let result = new RegExp(pattern);
+  if (aliasAsWord) result = alias(result, word);
+  return result;
+}

--- a/lang/semgrep-grammars/src/semgrep-php/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-php/test/corpus/semgrep.txt
@@ -435,3 +435,44 @@ $x = $$FOO;
     (assignment_expression
       left: (variable_name (name))
       right: (dynamic_variable_name (variable_name (name))))))
+
+==========================
+Metavar typed parameter
+==========================
+
+<?php
+function foo($T $X, int $y) { return 1; }
+
+---
+
+(program
+  (php_tag)
+  (function_definition
+    name: (name)
+    parameters: (formal_parameters
+      (simple_parameter
+        type: (type_list (named_type (semgrep_metavar_ident)))
+        name: (variable_name (name)))
+      (simple_parameter
+        type: (type_list (primitive_type))
+        name: (variable_name (name))))
+    body: (compound_statement
+      (return_statement (integer)))))
+
+==========================
+Metavar return type
+==========================
+
+<?php
+function foo(): $R { return 1; }
+
+---
+
+(program
+  (php_tag)
+  (function_definition
+    name: (name)
+    parameters: (formal_parameters)
+    return_type: (type_list (named_type (semgrep_metavar_ident)))
+    body: (compound_statement
+      (return_statement (integer)))))

--- a/lang/semgrep-grammars/src/semgrep-php/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-php/test/corpus/semgrep.txt
@@ -1,0 +1,437 @@
+==========================
+Ellipsis as a statement
+==========================
+
+<?php
+foo();
+...;
+bar();
+
+---
+
+(program
+  (php_tag)
+  (expression_statement (function_call_expression function: (name) arguments: (arguments)))
+  (semgrep_ellipsis)
+  (empty_statement)
+  (expression_statement (function_call_expression function: (name) arguments: (arguments))))
+
+==========================
+Ellipsis as an argument
+==========================
+
+<?php
+foo(1, ..., 2);
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (function_call_expression
+      function: (name)
+      arguments: (arguments
+        (argument (integer))
+        (argument (semgrep_ellipsis))
+        (argument (integer))))))
+
+==========================
+Variadic metavariable as argument
+==========================
+
+<?php
+foo($...ARGS);
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (function_call_expression
+      function: (name)
+      arguments: (arguments
+        (argument (semgrep_variadic_metavariable))))))
+
+==========================
+Ellipsis as a parameter
+==========================
+
+<?php
+function foo(...) { return 1; }
+
+---
+
+(program
+  (php_tag)
+  (function_definition
+    name: (name)
+    parameters: (formal_parameters (semgrep_ellipsis))
+    body: (compound_statement
+      (return_statement (integer)))))
+
+==========================
+Variadic metavariable as parameter
+==========================
+
+<?php
+function foo($...ARGS) { return 1; }
+
+---
+
+(program
+  (php_tag)
+  (function_definition
+    name: (name)
+    parameters: (formal_parameters (semgrep_variadic_metavariable))
+    body: (compound_statement
+      (return_statement (integer)))))
+
+==========================
+Deep ellipsis expression
+==========================
+
+<?php
+$x = <...foo($y)...>;
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      left: (variable_name (name))
+      right: (semgrep_deep_ellipsis
+        (function_call_expression
+          function: (name)
+          arguments: (arguments (argument (variable_name (name)))))))))
+
+==========================
+Ellipsis inside class body
+==========================
+
+<?php
+class C {
+  ...
+  public function foo() {}
+  ...
+}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    name: (name)
+    body: (declaration_list
+      (semgrep_ellipsis)
+      (method_declaration
+        (visibility_modifier)
+        name: (name)
+        parameters: (formal_parameters)
+        body: (compound_statement))
+      (semgrep_ellipsis))))
+
+==========================
+Ellipsis inside method body
+==========================
+
+<?php
+class C {
+  public function foo() {
+    ...;
+    bar();
+    ...
+  }
+}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    name: (name)
+    body: (declaration_list
+      (method_declaration
+        (visibility_modifier)
+        name: (name)
+        parameters: (formal_parameters)
+        body: (compound_statement
+          (expression_statement (semgrep_ellipsis))
+          (expression_statement (function_call_expression function: (name) arguments: (arguments)))
+          (semgrep_ellipsis))))))
+
+==========================
+Ellipsis inside enum body
+==========================
+
+<?php
+enum Suit {
+  ...
+  case Hearts;
+  ...
+}
+
+---
+
+(program
+  (php_tag)
+  (enum_declaration
+    name: (name)
+    body: (enum_declaration_list
+      (semgrep_ellipsis)
+      (enum_case name: (name))
+      (semgrep_ellipsis))))
+
+==========================
+Ellipsis inside match block
+==========================
+
+<?php
+$x = match($v) {
+  1 => 'a',
+  ...,
+  2 => 'b',
+};
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      left: (variable_name (name))
+      right: (match_expression
+        condition: (parenthesized_expression (variable_name (name)))
+        body: (match_block
+          (match_conditional_expression
+            conditional_expressions: (match_condition_list (integer))
+            return_expression: (string))
+          (semgrep_ellipsis)
+          (match_conditional_expression
+            conditional_expressions: (match_condition_list (integer))
+            return_expression: (string)))))))
+
+==========================
+Metavar as class name
+==========================
+
+<?php
+class $C {
+  public function foo() {}
+}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    name: (semgrep_metavar_ident)
+    body: (declaration_list
+      (method_declaration
+        (visibility_modifier)
+        name: (name)
+        parameters: (formal_parameters)
+        body: (compound_statement)))))
+
+==========================
+Metavar as interface name
+==========================
+
+<?php
+interface $I {}
+
+---
+
+(program
+  (php_tag)
+  (interface_declaration
+    name: (semgrep_metavar_ident)
+    body: (declaration_list)))
+
+==========================
+Metavar as trait name
+==========================
+
+<?php
+trait $T {}
+
+---
+
+(program
+  (php_tag)
+  (trait_declaration
+    name: (semgrep_metavar_ident)
+    body: (declaration_list)))
+
+==========================
+Metavar as enum name
+==========================
+
+<?php
+enum $E {
+  case A;
+}
+
+---
+
+(program
+  (php_tag)
+  (enum_declaration
+    name: (semgrep_metavar_ident)
+    body: (enum_declaration_list
+      (enum_case name: (name)))))
+
+==========================
+Metavar as function name
+==========================
+
+<?php
+function $F() { return 1; }
+
+---
+
+(program
+  (php_tag)
+  (function_definition
+    name: (semgrep_metavar_ident)
+    parameters: (formal_parameters)
+    body: (compound_statement
+      (return_statement (integer)))))
+
+==========================
+Metavar as method name
+==========================
+
+<?php
+class C {
+  public function $M() {}
+}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    name: (name)
+    body: (declaration_list
+      (method_declaration
+        (visibility_modifier)
+        name: (semgrep_metavar_ident)
+        parameters: (formal_parameters)
+        body: (compound_statement)))))
+
+==========================
+Metavar as type
+==========================
+
+<?php
+function foo($T $x) { return $x; }
+
+---
+
+(program
+  (php_tag)
+  (function_definition
+    name: (name)
+    parameters: (formal_parameters
+      (simple_parameter
+        type: (type_list (named_type (semgrep_metavar_ident)))
+        name: (variable_name (name))))
+    body: (compound_statement
+      (return_statement (variable_name (name))))))
+
+==========================
+Metavar in extends clause
+==========================
+
+<?php
+class C extends $B {}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    name: (name)
+    (base_clause (semgrep_metavar_ident))
+    body: (declaration_list)))
+
+==========================
+Metavar in implements clause
+==========================
+
+<?php
+class C implements $I {}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    name: (name)
+    (class_interface_clause (semgrep_metavar_ident))
+    body: (declaration_list)))
+
+==========================
+Metavar as attribute
+==========================
+
+<?php
+#[$A]
+class C {}
+
+---
+
+(program
+  (php_tag)
+  (class_declaration
+    attributes: (attribute_list (attribute (semgrep_metavar_ident)))
+    name: (name)
+    body: (declaration_list)))
+
+==========================
+Method call with ellipsis
+==========================
+
+<?php
+$obj->foo(...);
+$obj->bar(1, ..., 3);
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (member_call_expression
+      object: (variable_name (name))
+      name: (name)
+      arguments: (arguments (argument (semgrep_ellipsis)))))
+  (expression_statement
+    (member_call_expression
+      object: (variable_name (name))
+      name: (name)
+      arguments: (arguments
+        (argument (integer))
+        (argument (semgrep_ellipsis))
+        (argument (integer))))))
+
+==========================
+Variable-variable still parses ($$F)
+==========================
+
+<?php
+$$F = 1;
+$x = $$FOO;
+
+---
+
+(program
+  (php_tag)
+  (expression_statement
+    (assignment_expression
+      left: (dynamic_variable_name (variable_name (name)))
+      right: (integer)))
+  (expression_statement
+    (assignment_expression
+      left: (variable_name (name))
+      right: (dynamic_variable_name (variable_name (name))))))


### PR DESCRIPTION
## Summary

The PHP Semgrep grammar augmentation file at `lang/semgrep-grammars/src/semgrep-php/grammar.js` was a no-op (entire `rules` block commented out). PHP variables natively start with `$` so simple `$X`-style metavariable patterns parsed as PHP variables, but every other Semgrep construct (ellipsis in non-variadic positions, `$...ARGS`, metavar-as-class/function/type/attribute name) failed.

This PR builds out the PHP augmentation, modeled on `semgrep-java` and `semgrep-kotlin`. Closes LANG-474, LANG-475.

Companion release PR: semgrep/semgrep-php#4

### What's added

- `semgrep_ellipsis` (`...`) wired into expression, statement, member-declaration (class/interface/trait), enum-body, formal-parameter, match-arm positions.
- `semgrep_deep_ellipsis` (`<... expr ...>`) in expression position.
- `semgrep_variadic_metavariable` (`$...ARGS`) in formal-parameter and argument positions.
- `semgrep_metavar_ident` (`$FOO` in identifier position) wired into class/interface/trait/enum/function/method names, named types, base/interface clauses, and attribute names.

### `$$F` lexer interaction

PHP's variable-variable form `$$F` keeps its native meaning (`dynamic_variable_name($variable_name(F))`) because `semgrep_metavar_ident` is only accepted in identifier positions, not variable positions. This means the LANG-475 "metavar property name with `$$F`" sub-case (`class $C { public $T $$F = $V; }`) is NOT addressed in this PR — `$$F` continues to be parsed as variable-variable. That edge case can be tackled in a follow-up if needed, since this PR already unblocks the much larger set of patterns covered in LANG-474's triage. A regression test verifies `$$F` still parses correctly.

## Test plan

- [x] `make build && make test` in `lang/semgrep-grammars/src/semgrep-php/` (all 105 tests pass: 81 inherited + 24 new semgrep tests, including a regression test that `$$F` still parses as variable-variable).
- [x] Companion PR in `semgrep/semgrep-php` to release the regenerated parser: semgrep/semgrep-php#4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)