### PR TITLE
[c-sharp] fix Semgrep pattern parsing for top-level expressions, declarations, and ellipsis positions

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -23,16 +23,35 @@ module.exports = grammar(standard_grammar, {
 
   conflicts: ($, previous) => [
     ...previous,
-    [$._expression, $.parameter]
+    [$._expression, $.parameter],
+    // Top-level property pattern (e.g. `public $T $P { get; init; }`)
+    // overlaps with `implicit_parameter` lookahead on `_type identifier`.
+    [$.implicit_parameter, $.property_declaration],
   ],
 
   rules: {
 
     // Entry point
+    //
+    // We add a bare top-level expression alternative so that Semgrep
+    // patterns like `$X is null`, `$X with { ... }`, `($X) => $E`,
+    // `$X?.$Y`, `typeof($T)`, `$X..$Y`, `$X[..$Y]`, `init $X => $Y`,
+    // `from $X in $Y select $E`, or `$\"hello {$X}\"` parse without
+    // requiring the `__SEMGREP_EXPRESSION` sentinel.
+    //
+    // We also add a bare `property_declaration` alternative so that
+    // `public $T $P { get; init; }` is not mis-parsed as a
+    // `local_declaration_statement` followed by a stray block.
+    //
+    // Both extra alternatives are given a strongly negative dynamic
+    // precedence so they only win when nothing else parses the input —
+    // a normal C# program still resolves through `previous`.
     compilation_unit: ($, previous) => {
       return choice(
         previous,
-        $.semgrep_expression
+        $.semgrep_expression,
+        prec.dynamic(-100, $._expression),
+        prec.dynamic(-100, $.property_declaration)
       );
     },
 
@@ -101,7 +120,30 @@ module.exports = grammar(standard_grammar, {
 	  $.ellipsis,
     ),
 
+    // Allow `...` as a switch-expression arm,
+    // e.g. `$X switch { $P => $E, ... }`.
+    switch_expression_arm: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
+
+    // Allow `<...>` in a generic type parameter list,
+    // e.g. `class $C<...> { }`.
+    type_parameter: ($, previous) => choice(
+      previous,
+      $.ellipsis,
+    ),
+
     // Statement ellipsis: '...' not followed by ';'
+    //
+    // We also extend `expression_statement` to accept additional Semgrep
+    // expression-pattern shapes that the upstream
+    // `_expression_statement_expression` does not allow (it admits only
+    // assignment / invocation / unary / await / object-creation /
+    // parenthesized). Without these, patterns like `$X is $T $Y;`,
+    // `$"hello {$X}";`, `$X?.$Y;`, `typeof($T);`, `$X[..$Y];`,
+    // `$X..$Y;`, and `init $X => $Y;` would parse the expression at the
+    // top level but error on the trailing `;`.
     expression_statement: ($, previous) => {
       return choice(
         previous,
@@ -110,7 +152,16 @@ module.exports = grammar(standard_grammar, {
         seq($.deep_ellipsis, ';'),
         seq($.member_access_ellipsis_expression, ';'),
         seq($._semgrep_metavariable, ';'),
-        seq($.typed_metavariable, ';')
+        seq($.typed_metavariable, ';'),
+        // Semgrep-specific top-level expression shapes that upstream's
+        // `_expression_statement_expression` rejects.
+        seq($.is_pattern_expression, ';'),
+        seq($.interpolated_string_expression, ';'),
+        seq($.lambda_expression, ';'),
+        seq($.conditional_access_expression, ';'),
+        seq($.type_of_expression, ';'),
+        seq($.element_access_expression, ';'),
+        seq($.range_expression, ';'),
       );
     },
 

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -408,3 +408,252 @@ namespace $N;
         (ellipsis)))
     (identifier)
     (ellipsis)))
+
+================================================================================
+Top-level is-pattern with null
+================================================================================
+
+$X is null
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (is_pattern_expression
+    (identifier)
+    (constant_pattern
+      (null_literal))))
+
+================================================================================
+Top-level with expression
+================================================================================
+
+$X with { $P = $V }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (with_expression
+    (identifier)
+    (with_initializer_expression
+      (simple_assignment_expression
+        (identifier)
+        (identifier)))))
+
+================================================================================
+Top-level is-pattern with property pattern
+================================================================================
+
+$X is { $P: $V }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (is_pattern_expression
+    (identifier)
+    (recursive_pattern
+      (property_pattern_clause
+        (subpattern
+          (expression_colon
+            (identifier))
+          (constant_pattern
+            (identifier)))))))
+
+================================================================================
+Top-level LINQ query expression
+================================================================================
+
+from $X in $Y where $C select $E
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (query_expression
+    (from_clause
+      (identifier)
+      (identifier))
+    (where_clause
+      (identifier))
+    (select_clause
+      (identifier))))
+
+================================================================================
+Top-level property with accessors
+================================================================================
+
+public $T $P { get; init; }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (property_declaration
+    (modifier)
+    (identifier)
+    (identifier)
+    (accessor_list
+      (accessor_declaration)
+      (accessor_declaration))))
+
+================================================================================
+Is-pattern declaration as expression statement
+================================================================================
+
+$X is $T $Y;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (is_pattern_expression
+        (identifier)
+        (declaration_pattern
+          (identifier)
+          (identifier))))))
+
+================================================================================
+Interpolated string as expression statement
+================================================================================
+
+$"hello {$X} world";
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (interpolated_string_expression
+        (interpolated_string_text)
+        (interpolation
+          (identifier))
+        (interpolated_string_text)))))
+
+================================================================================
+Lambda as expression statement
+================================================================================
+
+($X) => $E;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (lambda_expression
+        (parameter_list
+          (parameter
+            (identifier)))
+        (identifier)))))
+
+================================================================================
+Conditional access as expression statement
+================================================================================
+
+$X?.$Y;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (conditional_access_expression
+        (identifier)
+        (member_binding_expression
+          (identifier))))))
+
+================================================================================
+Typeof as expression statement
+================================================================================
+
+typeof($T);
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (type_of_expression
+        (identifier)))))
+
+================================================================================
+Range expression as expression statement
+================================================================================
+
+$X..$Y;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (range_expression
+        (identifier)
+        (identifier)))))
+
+================================================================================
+Element access with range as expression statement
+================================================================================
+
+$X[..$Y];
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (global_statement
+    (expression_statement
+      (element_access_expression
+        (identifier)
+        (bracketed_argument_list
+          (argument
+            (range_expression
+              (identifier))))))))
+
+================================================================================
+Init-style expression-bodied property
+================================================================================
+
+init $X => $Y;
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (property_declaration
+    (identifier)
+    (identifier)
+    (arrow_expression_clause
+      (identifier))))
+
+================================================================================
+Switch arm ellipsis
+================================================================================
+
+__SEMGREP_EXPRESSION
+$X switch { $P => $E, ... }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (semgrep_expression
+    (switch_expression
+      (identifier)
+      (switch_expression_arm
+        (constant_pattern
+          (identifier))
+        (identifier))
+      (switch_expression_arm
+        (ellipsis)))))
+
+================================================================================
+Type parameter ellipsis
+================================================================================
+
+class $C<...> { }
+
+--------------------------------------------------------------------------------
+
+(compilation_unit
+  (class_declaration
+    (identifier)
+    (type_parameter_list
+      (type_parameter
+        (ellipsis)))
+    (declaration_list)))


### PR DESCRIPTION
## Summary

Augments `lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js` so several
modern C# pattern shapes that previously errored at parse time are now
admitted by the grammar.

### Changes

- Top-level bare `_expression` alternative on `compilation_unit` so
  patterns without a trailing `;` parse: `$X is null`,
  `$X with { ... }`, `$X is { $P: $V }`,
  `from $X in $Y where $C select $E`.
- Top-level bare `property_declaration` alternative so
  `public $T $P { get; init; }` parses (instead of being mis-tokenized
  as `local_declaration_statement` + stray block).
- `expression_statement` extended to accept C# 7/8/9+ expression
  shapes that the upstream `_expression_statement_expression` rejects:
  `is_pattern_expression`, `interpolated_string_expression`,
  `lambda_expression`, `conditional_access_expression`,
  `type_of_expression`, `element_access_expression`, and
  `range_expression`.
- `switch_expression_arm` accepts `$.ellipsis` so
  `$X switch { $P => $E, ... }` parses.
- `type_parameter` accepts `$.ellipsis` so `class $C<...> { }` parses.

The new top-level alternatives are gated with strongly negative
`prec.dynamic` so ordinary C# code still resolves through the existing
`previous` path. Targeted `conflicts` entries disambiguate the small
number of unavoidable overlaps.

### Tickets

- Closes LANG-478 (top-level expression patterns).
- Closes LANG-484 (top-level LINQ + property declarations).
- Partially addresses LANG-494 (augmentation parts only):
  switch-arm `...` and `<...>` type-parameter ellipsis are fixed here.
  The `I$I` metavariable+identifier concatenation case from LANG-494
  is deferred — it is labeled `fix:scanner-or-entrypoint` upstream and
  requires scanner-level work (`token.immediate` for zero-width
  adjacency, or pattern-preprocessing in semgrep-core).

## Test plan

- [x] `make build && make test` passes (188 corpus tests, 15 new).
- [x] `tree-sitter parse` spot-checked on every pattern listed in the
  three Linear tickets.
- [ ] Wait for CI on this PR.
- [ ] Land the companion `semgrep-c-sharp` SHA bump in
  `semgrep/semgrep-c-sharp`.