### PR TITLE
[hcl] add $...X ellipsis-metavariable and fix namespaced function calls

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-hcl/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-hcl/grammar.js
@@ -17,6 +17,12 @@ module.exports = grammar(base_grammar, {
      //  1:  object_start  (_expr_term  semgrep_ellipsis)  •  '['  …
      //  2:  object_start  (object_elem  semgrep_ellipsis)  •  '['  …
      [$._expr_term, $.object_elem],
+     // The new postfix `_expr_term get_attr ( ... )` (for chained
+     // callees like `$NS.$F($ARG)`) shares its prefix with the
+     // existing postfix `_expr_term get_attr` production. The `(` (or
+     // its absence) disambiguates, but tree-sitter needs this
+     // conflict declaration to keep both parses live.
+     [$._expr_term],
   ]),
 
   /*
@@ -46,6 +52,10 @@ module.exports = grammar(base_grammar, {
 
     _semgrep_metavariable: $ => token(/\$[A-Z_][A-Z_0-9]*/),
 
+    // Ellipsis-metavariable, e.g. `$...ARGS`. Lexed atomically so it wins
+    // over the `identifier` + `...` decomposition.
+    _semgrep_ellipsis_metavar: $ => token(/\$\.\.\.[A-Z_][A-Z_0-9]*/),
+
 
     // Ellipsis
     body: ($, previous) => repeat1(
@@ -53,23 +63,41 @@ module.exports = grammar(base_grammar, {
         $.attribute,
         $.block,
         $.semgrep_ellipsis,
+        $._semgrep_ellipsis_metavar,
       ),
      ),
 
     object_elem: ($, previous) => {
       return choice(
         previous,
-        $.semgrep_ellipsis
+        $.semgrep_ellipsis,
+        $._semgrep_ellipsis_metavar
       );
     },
 
-    _expr_term: ($, previous) => {
-      return choice(
-        previous,
-        $.semgrep_ellipsis,
-        $.deep_ellipsis
-      );
-    },
+    // Adds support for:
+    //   - semgrep ellipsis (`...`) and `<... e ...>` deep ellipsis;
+    //   - the ellipsis-metavariable token `$...X`;
+    //   - a postfix function-call production on `_expr_term` so that
+    //     calls with a `get_attr`-chain callee like `$NS.$F($ARG)`
+    //     or `provider.fn(arg)` parse correctly. The base grammar's
+    //     `function_call` (bare-identifier callee) still handles
+    //     `foo(x)` unchanged; this new branch reuses the existing
+    //     postfix `_expr_term get_attr` production for the callee
+    //     prefix, so `foo.bar` (no call) keeps its current parse.
+    _expr_term: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.deep_ellipsis,
+      $._semgrep_ellipsis_metavar,
+      seq(
+        $._expr_term,
+        $.get_attr,
+        $._function_call_start,
+        optional($.function_arguments),
+        $._function_call_end,
+      ),
+    ),
 
     semgrep_ellipsis: $ => '...',
 

--- a/lang/semgrep-grammars/src/semgrep-hcl/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-hcl/test/corpus/semgrep.txt
@@ -25,7 +25,7 @@ policy = jsonencode({
    ...
 })
 
-	 
+
 ---
 
 (config_file
@@ -37,3 +37,157 @@ policy = jsonencode({
 	        (object_start)
 		(object_elem (semgrep_ellipsis))
 		(object_end))))))))))
+
+=====================================
+Ellipsis-metavariable in tuple element
+=====================================
+
+x = [$...ITEMS]
+
+---
+
+(config_file
+  (body
+    (attribute
+      (identifier)
+      (expression
+        (collection_value
+          (tuple
+            (tuple_start)
+            (expression)
+            (tuple_end)))))))
+
+=====================================
+Ellipsis-metavariable in function arguments
+=====================================
+
+x = $F($...ARGS)
+
+---
+
+(config_file
+  (body
+    (attribute
+      (identifier)
+      (expression
+        (function_call
+          (identifier)
+          (function_arguments
+            (expression)))))))
+
+=====================================
+Ellipsis-metavariable as attribute value
+=====================================
+
+policy = jsonencode($...POLICY)
+
+---
+
+(config_file
+  (body
+    (attribute
+      (identifier)
+      (expression
+        (function_call
+          (identifier)
+          (function_arguments
+            (expression)))))))
+
+=====================================
+Ellipsis-metavariable as block body element
+=====================================
+
+resource "aws_s3_bucket" "$NAME" {
+  $...KEYS
+}
+
+---
+
+(config_file
+  (body
+    (block
+      (identifier)
+      (string_lit
+        (quoted_template_start)
+        (template_literal)
+        (quoted_template_end))
+      (string_lit
+        (quoted_template_start)
+        (template_literal)
+        (quoted_template_end))
+      (block_start)
+      (body)
+      (block_end))))
+
+=====================================
+Ellipsis-metavariable as attribute RHS
+=====================================
+
+resource "aws_s3_bucket" "$NAME" {
+  tags = $...TAGS
+}
+
+---
+
+(config_file
+  (body
+    (block
+      (identifier)
+      (string_lit
+        (quoted_template_start)
+        (template_literal)
+        (quoted_template_end))
+      (string_lit
+        (quoted_template_start)
+        (template_literal)
+        (quoted_template_end))
+      (block_start)
+      (body
+        (attribute
+          (identifier)
+          (expression)))
+      (block_end))))
+
+=====================================
+Namespaced metavariable function call
+=====================================
+
+x = $NS.$F($ARG)
+
+---
+
+(config_file
+  (body
+    (attribute
+      (identifier)
+      (expression
+        (variable_expr
+          (identifier))
+        (get_attr
+          (identifier))
+        (function_arguments
+          (expression
+            (variable_expr
+              (identifier))))))))
+
+=====================================
+Namespaced function call (no metavars)
+=====================================
+
+x = foo.bar(y)
+
+---
+
+(config_file
+  (body
+    (attribute
+      (identifier)
+      (expression
+        (variable_expr
+          (identifier))
+        (get_attr
+          (identifier))
+        (function_arguments
+          (expression
+            (variable_expr
+              (identifier))))))))


### PR DESCRIPTION
## Summary

Two semgrep-pattern parsing bugs in HCL/Terraform:

- **LANG-490** — `$...X` ellipsis-metavariable was unsupported in every
  syntactic position (block body, attribute value, tuple element,
  function-call arg list, function arguments). Added a new atomic token
  `_semgrep_ellipsis_metavar: token(/\$\.\.\.[A-Z_][A-Z_0-9]*/)` and
  wired it into `body`, `object_elem`, and `_expr_term` (which
  transitively covers tuple elements and function arguments).

- **LANG-498** — `$NS.$F($ARG)` (and more generally
  `provider.fn(arg)`) failed to parse because `function_call` only
  accepted a bare-identifier callee. Rather than widening
  `function_call`'s callee directly (which collides with the postfix
  `_expr_term get_attr` recursion in a way tree-sitter cannot resolve
  with `conflicts` or static `prec` alone), I added a new postfix
  production on `_expr_term`:

  ```js
  seq($._expr_term, $.get_attr, $._function_call_start,
      optional($.function_arguments), $._function_call_end)
  ```

  This shares the `_expr_term get_attr` prefix with the existing
  attribute-access production, which is a real LR conflict that
  tree-sitter detects and asks us to declare; a new `[$._expr_term]`
  conflicts entry keeps both parses live until the trailing `(` (or
  its absence) disambiguates. Plain `foo.bar` and bare-identifier
  `foo(x)` continue to parse exactly as before.

Downstream release: semgrep/semgrep-hcl#2.

### Conflicts / precedence note

I tried the ticket's suggested approach first — widening
`function_call` to `seq($.identifier, repeat($.get_attr), '(', ..., ')')`
with a `[$.variable_expr, $.function_call]` /
`[$._expr_term, $.function_call]` conflict declaration. tree-sitter
consistently reported these as "unnecessary conflicts" (its LR
analyzer treated the choice as unambiguous and committed
deterministically): with no static `prec` the parser broke `foo.bar`
(chose `function_call`); with `prec(-1)` it broke `foo.bar(x)` and
`$NS.$F($ARG)` (committed to `variable_expr` before seeing `(`);
`prec.dynamic` had no effect because tree-sitter never explored the
alternate path. Refactoring the callee into a separate
`_function_callee` rule with conflicts on that didn't help either,
for the same reason.

The postfix-on-`_expr_term` formulation works because
`_expr_term get_attr` is now a genuine shared prefix between the
plain-attribute-access reading and the new chained-callee call, which
tree-sitter detects as a real LR conflict and resolves correctly with
the `[$._expr_term]` declaration.

## Test plan

- [x] `cd lang/semgrep-grammars/src/semgrep-hcl && make && make test`
      — all 85 corpus tests pass (76 inherited from upstream
      `tree-sitter-hcl` + 9 in `test/corpus/semgrep.txt`)
- [x] Added 7 new fixtures under `test/corpus/semgrep.txt` covering
      every position from LANG-490 and the namespaced-call case from
      LANG-498
- [x] Spot-checked: `foo.bar`, `foo(x)`, `foo.bar(y)`, `$NS.$F($ARG)`,
      `[$...ITEMS]`, `$F($...ARGS)`, `policy = jsonencode($...POLICY)`,
      `tags = $...TAGS`, and `$...KEYS` as a block-body element all
      parse without `(ERROR ...)` nodes
- [x] Downstream release: semgrep/semgrep-hcl#2 (SHA `1da0c67`)

Tickets: LANG-490, LANG-498

🤖 Generated with [Claude Code](https://claude.com/claude-code)