### PR TITLE
[typescript] fix Semgrep pattern parsing for TS-specific positions (decorators, types, interfaces, enums)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
+++ b/lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js
@@ -6,6 +6,18 @@
  * Even if we only use one of these parsers to parse patterns, it's simpler to
  * keep the CSTs the same and there's little downside in doing so.
  */
+
+// Local copies of the upstream helpers in
+// `tree-sitter-typescript/common/define-grammar.js`. We re-define them here
+// because they are not exported, but we need the same shapes when we replace
+// upstream rules wholesale (e.g. `object_type`, `enum_body`, `type_parameters`).
+function sepBy1(sep, rule) {
+  return seq(rule, repeat(seq(sep, rule)));
+}
+function commaSep1(rule) {
+  return sepBy1(',', rule);
+}
+
 module.exports = {
   conflicts: ($, previous) => previous.concat([
     [$.semgrep_expression_ellipsis, $.spread_element],
@@ -30,6 +42,75 @@ module.exports = {
     [$.spread_element, $.rest_pattern, $.semgrep_ellipsis],
     [$.spread_element, $.rest_pattern, $.semgrep_ellipsis, $.semgrep_expression_ellipsis],
     [$.statement, $.pair, $.pair_pattern],
+    // ----- Conflicts introduced by the LANG-477/489/500/502/504 extensions. -----
+    // LANG-489: `...` in type position conflicts with `rest_type` (`...` + type).
+    [$.semgrep_ellipsis, $.rest_type, $.primary_type],
+    // LANG-477/489: at the top of `semgrep_pattern`, `Foo` could be a
+    // `primary_expression` or the head of a `generic_type`.
+    [$.primary_expression, $._property_name, $.generic_type],
+    // LANG-489: `readonly` can lead either a `readonly_type` or a `_property_name`.
+    [$._property_name, $.readonly_type],
+    [$._property_name, $.constructor_type],
+    [$._property_name, $.generic_type],
+    // LANG-489: a bare `...` at the top level could be either a `pair` ellipsis
+    // or a `primary_type` ellipsis.
+    [$.pair, $.primary_type],
+    // LANG-500: `{ ... }` could be an object literal/pattern or `object_type`.
+    [$.pair, $.pair_pattern, $.object_type],
+    // LANG-489: `(...)` is parenthesized type / parenthesized expression /
+    // parameter pattern.
+    [$._formal_parameter, $.pattern, $.primary_type],
+    // LANG-489: `[...` could begin a tuple type, array pattern, array literal,
+    // or be a stand-alone ellipsis.
+    [$.spread_element, $.rest_pattern, $.rest_type, $.semgrep_ellipsis, $.semgrep_expression_ellipsis],
+    [$.rest_pattern, $.rest_type, $.semgrep_ellipsis],
+    [$.rest_pattern, $.rest_type, $.semgrep_ellipsis, $.semgrep_expression_ellipsis],
+    [$.rest_pattern, $.rest_type, $.semgrep_expression_ellipsis],
+    [$.rest_pattern, $.semgrep_ellipsis, $.semgrep_expression_ellipsis],
+    [$.rest_type, $.semgrep_ellipsis, $.semgrep_expression_ellipsis],
+    [$.rest_type, $.semgrep_ellipsis],
+    // LANG-489: `[id : type]` ambiguity between an `index_signature` and a
+    // tuple-type element with a `type_annotation`.
+    [$.type_annotation, $.index_signature],
+    // LANG-477: standalone decorator pattern collides with method/field patterns.
+    [$.method_definition, $.method_signature, $.existential_type],
+    // LANG-504: `<...>` is ambiguous between `<primary_type>` and
+    // `<type_parameter, ...>`.
+    [$.primary_type, $.type_parameters],
+    // LANG-489: `const` could begin a `lexical_declaration` (statement) or
+    // be the literal `const` of `primary_type`.
+    [$.lexical_declaration, $.primary_type],
+    // LANG-489: a bare `...` at the top level can be a `pair` ellipsis,
+    // a `statement` ellipsis, or a `primary_type` ellipsis.
+    [$.statement, $.pair, $.primary_type],
+    // LANG-500: `{}` at the top level is ambiguous between an object literal,
+    // an object type, and a `statement_block`.
+    [$.statement_block, $.object, $.object_type],
+    // LANG-500: `{ ;` could begin an `object_type` (with a leading separator)
+    // or a `statement_block` containing an `empty_statement`.
+    [$.empty_statement, $.object_type],
+    // LANG-500: `{ static ...` is ambiguous between a `method_definition`/
+    // `method_signature`/`property_signature` (member-position) and a
+    // `primary_expression` (e.g. an identifier `static`).
+    [$.primary_expression, $.method_definition, $.method_signature, $.property_signature],
+    // LANG-500: same with `readonly`, which additionally introduces an
+    // `index_signature` ambiguity.
+    [$.primary_expression, $.method_definition, $.method_signature, $.property_signature, $.index_signature],
+    // LANG-500: `{ export ... }` could be a statement-block / object-type with
+    // an `export_statement` member.
+    [$.statement, $.object_type],
+    // LANG-500: `{ ... }` is ambiguous between several constructs that all
+    // accept `semgrep_ellipsis` as a member or sole content.
+    [$.statement, $.pair, $.pair_pattern, $.object_type],
+    // LANG-489 (statement extension side-effect): `var x = y(` — the `y` could
+    // be a `primary_expression` (in a normal statement) or part of an
+    // `assign_lambda` (`var x = y()...`).
+    [$.primary_expression, $.assign_lambda],
+    // LANG-489: `function NAME(...) { ... }` is now reachable both as a
+    // top-level `statement` (a `function_declaration`) and via
+    // `function_declaration_pattern` / `function_expression`.
+    [$.function_expression, $.function_declaration, $.function_declaration_pattern],
+    [$.function_declaration, $.function_declaration_pattern],
   ]),
 
 
@@ -80,6 +161,17 @@ module.exports = {
       $.finally_clause,
       $.catch_clause,
       $.assign_lambda,
+      // LANG-477: standalone decorator patterns: `@DEC`, `@DEC()`, `@DEC(...)`.
+      $.decorator,
+      // LANG-489 / LANG-500 / LANG-502: declaration-position patterns —
+      // `type T = ...`, `interface I { ... }`, `enum E { ... }`,
+      // `let X: ...`, `function $F<...>(...) { ... }`, etc. all live under
+      // `statement`/`declaration`, not `expression`.
+      $.statement,
+      // LANG-489: bare type-position patterns, e.g. `Pick<T, $K>`.
+      $.type,
+      // LANG-489: type predicates, e.g. `X is T`.
+      $.type_predicate,
     ),
 
     method_pattern: $ => choice(
@@ -225,6 +317,54 @@ module.exports = {
       '}'
     ),
 
+    // LANG-500: allow `...` as a member of `object_type`. Upstream defines
+    // `interface_body` as `alias($.object_type, $.interface_body)`, so this
+    // single override fixes both `interface I { ... }` and `type T = { ... }`.
+    // Mirrors the upstream `object_type` shape verbatim, with `semgrep_ellipsis`
+    // added as one extra member alternative.
+    object_type: $ => seq(
+      choice('{', '{|'),
+      optional(seq(
+        optional(choice(',', ';')),
+        sepBy1(
+          choice(',', $._semicolon),
+          choice(
+            $.export_statement,
+            $.property_signature,
+            $.call_signature,
+            $.construct_signature,
+            $.index_signature,
+            $.method_signature,
+            $.semgrep_ellipsis,
+          ),
+        ),
+        optional(choice(',', $._semicolon)),
+      )),
+      choice('}', '|}'),
+    ),
+
+    // LANG-502: allow `...` as a member of `enum_body`. Mirrors upstream verbatim.
+    enum_body: $ => seq(
+      '{',
+      optional(seq(
+        sepBy1(',', choice(
+          field('name', $._property_name),
+          $.enum_assignment,
+          $.semgrep_ellipsis,
+        )),
+        optional(','),
+      )),
+      '}',
+    ),
+
+    // LANG-504: allow `<...>` and `<$T, ...>` in generic-parameter lists.
+    type_parameters: $ => seq(
+      '<',
+      commaSep1(choice($.type_parameter, $.semgrep_ellipsis)),
+      optional(','),
+      '>',
+    ),
+
     member_expression: $ => prec('member', seq(
       field('object', choice($.expression, $.primary_expression, $.import)),
       choice('.', field('optional_chain', $.optional_chain)),
@@ -270,6 +410,18 @@ module.exports = {
       previous,
       $.semgrep_expression_ellipsis,
       $.deep_ellipsis,
+      $.semgrep_metavar_ellipsis,
+    ),
+
+    // LANG-489 / LANG-504: admit `...` and `$X` (and `$...X`) wherever a type
+    // is expected. `primary_type` is reachable from `type` and from every
+    // `_type`-typed slot (type alias RHS, type annotation, conditional-type
+    // sides, mapped-type value, tuple types, generic type arguments), so a
+    // single extension covers all of those positions.
+    primary_type: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.semgrep_metavariable,
       $.semgrep_metavar_ellipsis,
     ),
 

--- a/lang/semgrep-grammars/src/semgrep-typescript/typescript/corpus/semgrep-ext.txt
+++ b/lang/semgrep-grammars/src/semgrep-typescript/typescript/corpus/semgrep-ext.txt
@@ -154,3 +154,278 @@ function foo(..., @Bar(...) $X, ...) { ... }
     (statement_block
       (expression_statement
         (semgrep_expression_ellipsis)))))
+
+==================================
+Standalone decorator (LANG-477)
+==================================
+
+__SEMGREP_EXPRESSION @DEC
+
+---
+
+(program
+  (semgrep_expression
+    (semgrep_pattern
+      (decorator
+        (identifier)))))
+
+==================================
+Standalone decorator call (LANG-477)
+==================================
+
+__SEMGREP_EXPRESSION @DEC()
+
+---
+
+(program
+  (semgrep_expression
+    (semgrep_pattern
+      (decorator
+        (call_expression
+          (identifier)
+          (arguments))))))
+
+==================================
+Standalone decorator with ellipsis args (LANG-477)
+==================================
+
+__SEMGREP_EXPRESSION @DEC(...)
+
+---
+
+(program
+  (semgrep_expression
+    (semgrep_pattern
+      (decorator
+        (call_expression
+          (identifier)
+          (arguments
+            (semgrep_expression_ellipsis)))))))
+
+==================================
+Type alias RHS ellipsis (LANG-489)
+==================================
+
+type T = ...
+
+---
+
+(program
+  (type_alias_declaration
+    (type_identifier)
+    (semgrep_ellipsis)))
+
+==================================
+Type annotation ellipsis (LANG-489)
+==================================
+
+let X: ...
+
+---
+
+(program
+  (lexical_declaration
+    (variable_declarator
+      (identifier)
+      (type_annotation
+        (semgrep_ellipsis)))))
+
+==================================
+Conditional type with ellipsis (LANG-489)
+==================================
+
+type T = X extends Y ? ... : ...
+
+---
+
+(program
+  (type_alias_declaration
+    (type_identifier)
+    (conditional_type
+      (type_identifier)
+      (type_identifier)
+      (semgrep_ellipsis)
+      (semgrep_ellipsis))))
+
+==================================
+Type predicate (LANG-489)
+==================================
+
+__SEMGREP_EXPRESSION X is T
+
+---
+
+(program
+  (semgrep_expression
+    (semgrep_pattern
+      (type_predicate
+        (identifier)
+        (type_identifier)))))
+
+==================================
+Interface body ellipsis (LANG-500)
+==================================
+
+interface I { ... }
+
+---
+
+(program
+  (interface_declaration
+    (type_identifier)
+    (interface_body
+      (semgrep_ellipsis))))
+
+==================================
+Interface body with member and ellipsis (LANG-500)
+==================================
+
+interface I { foo(): T; ... }
+
+---
+
+(program
+  (interface_declaration
+    (type_identifier)
+    (interface_body
+      (method_signature
+        (property_identifier)
+        (formal_parameters)
+        (type_annotation
+          (type_identifier)))
+      (semgrep_ellipsis))))
+
+==================================
+Interface extends with ellipsis body (LANG-500)
+==================================
+
+interface I extends B { ... }
+
+---
+
+(program
+  (interface_declaration
+    (type_identifier)
+    (extends_type_clause
+      (type_identifier))
+    (interface_body
+      (semgrep_ellipsis))))
+
+==================================
+Object type literal ellipsis (LANG-500)
+==================================
+
+type T = { ... }
+
+---
+
+(program
+  (type_alias_declaration
+    (type_identifier)
+    (object_type
+      (semgrep_ellipsis))))
+
+==================================
+Object type literal with member and ellipsis (LANG-500)
+==================================
+
+type T = { K: V; ... }
+
+---
+
+(program
+  (type_alias_declaration
+    (type_identifier)
+    (object_type
+      (property_signature
+        (property_identifier)
+        (type_annotation
+          (type_identifier)))
+      (semgrep_ellipsis))))
+
+==================================
+Empty enum body ellipsis (LANG-502)
+==================================
+
+enum E { ... }
+
+---
+
+(program
+  (enum_declaration
+    (identifier)
+    (enum_body
+      (semgrep_ellipsis))))
+
+==================================
+Enum body with member and ellipsis (LANG-502)
+==================================
+
+enum E { A, ... }
+
+---
+
+(program
+  (enum_declaration
+    (identifier)
+    (enum_body
+      (property_identifier)
+      (semgrep_ellipsis))))
+
+==================================
+Mapped type value ellipsis (LANG-504)
+==================================
+
+type T<X> = { [K in keyof X]: ... }
+
+---
+
+(program
+  (type_alias_declaration
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier)))
+    (object_type
+      (index_signature
+        (mapped_type_clause
+          (type_identifier)
+          (index_type_query
+            (type_identifier)))
+        (type_annotation
+          (semgrep_ellipsis))))))
+
+==================================
+Type-parameter ellipsis on function (LANG-504)
+==================================
+
+function F<...>(X) { }
+
+---
+
+(program
+  (function_declaration
+    (identifier)
+    (type_parameters
+      (semgrep_ellipsis))
+    (formal_parameters
+      (required_parameter
+        (identifier)))
+    (statement_block)))
+
+==================================
+Type-parameter ellipsis on class (LANG-504)
+==================================
+
+class C<$T, ...> { }
+
+---
+
+(program
+  (class_declaration
+    (type_identifier)
+    (type_parameters
+      (type_parameter
+        (type_identifier))
+      (semgrep_ellipsis))
+    (class_body)))


### PR DESCRIPTION
## Summary

Extends `lang/semgrep-grammars/src/semgrep-typescript/common/semgrep-ext.js` so Semgrep patterns parse cleanly in positions that are unique to TypeScript:

- **LANG-477** — standalone decorator patterns (`@$DEC`, `@$DEC()`, `@$DEC(...)`).
- **LANG-489** — bare types and type predicates as patterns; `...` and metavariables in any `_type`-typed slot (type alias RHS, type annotation, conditional-type sides, mapped-type value, tuple types, generic type arguments).
- **LANG-500** — `...` as a member of `object_type` (which propagates to `interface_body` via `alias($.object_type, $.interface_body)`).
- **LANG-502** — `...` as a member of `enum_body`.
- **LANG-504** — `<...>` and `<$T, ...>` in `type_parameters`; the mapped-type RHS case is subsumed by the LANG-489 `primary_type` extension.

`semgrep_pattern` also now admits `$.statement` so declaration-position patterns like `interface I { ... }`, `enum E { ... }`, `type T = ...`, and `let X: ...` parse as Semgrep patterns under the `__SEMGREP_EXPRESSION` entry point.

Companion regeneration PRs:
- semgrep/semgrep-typescript#3
- semgrep/semgrep-tsx#2

## Test plan

- [x] `make build` from `lang/semgrep-grammars/src/semgrep-typescript/` regenerates both `typescript/` and `tsx/` parsers without unresolved conflicts.
- [x] `tree-sitter parse` on every reproducer from the LANG-477/489/500/502/504 tickets produces an `ERROR`-free tree (verified for both `__SEMGREP_EXPRESSION`-wrapped and bare forms).
- [x] Existing `corpus/semgrep-ext.txt` cases (expression ellipsis, class-body ellipsis, function-parameter ellipsis, decorator-prefixed method patterns) still parse to the same trees.

## Tickets

- LANG-477 — Standalone decorator patterns rejected
- LANG-489 — Type-position patterns rejected
- LANG-500 — Interface bodies / object type literals reject `...`
- LANG-502 — Enum bodies reject `...`
- LANG-504 — Mapped-type value / generic type-parameter lists reject `...`

🤖 Generated with [Claude Code](https://claude.com/claude-code)