### PR TITLE
[c] add Semgrep grammar augmentation (was empty)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-c/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c/grammar.js
@@ -17,15 +17,62 @@ module.exports = grammar(base_grammar, {
      if they're not already part of the base grammar.
   */
   rules: {
-  /*
-    semgrep_ellipsis: $ => '...',
 
-    _expression: ($, previous) => {
-      return choice(
-        $.semgrep_ellipsis,
-        ...previous.members
-      );
-    }
-  */
+    // Entry point: allow parsing a standalone semgrep expression.
+    translation_unit: ($, previous) => choice(
+      previous,
+      $.semgrep_expression
+    ),
+
+    semgrep_expression: $ => seq('__SEMGREP_EXPRESSION', $._expression),
+
+    // Typed metavariables: e.g. (int $X)
+    semgrep_metavar: $ => /\$[A-Z_][A-Z_0-9]*/,
+
+    semgrep_typed_metavar: $ => seq(
+      $.type_descriptor,
+      $.semgrep_metavar
+    ),
+
+    parenthesized_expression: ($, previous) => choice(
+      previous,
+      seq('(', $.semgrep_typed_metavar, ')')
+    ),
+
+    // Ellipsis variants
+    semgrep_ellipsis: $ => '...',
+    deep_ellipsis: $ => seq('<...', $._expression, '...>'),
+    semgrep_named_ellipsis: $ => /\$\.\.\.[A-Z_][A-Z_0-9]*/,
+
+    _expression: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis,
+      $.deep_ellipsis,
+      $.semgrep_named_ellipsis
+    ),
+
+    // Allow `{ ... }` to reduce to a block item rather than just an expression.
+    _block_item: ($, previous) => choice(
+      previous,
+      prec(1, $.semgrep_ellipsis)
+    ),
+
+    // Allow `...` at the top level.
+    _top_level_item: ($, previous) => choice(
+      previous,
+      prec(1, $.semgrep_ellipsis)
+    ),
+
+    // Allow `...` as a struct field, e.g. struct $S { $T $F; ... };
+    _field_declaration_list_item: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis
+    ),
+
+    // For method chaining, e.g. foo. ... .bar()
+    _field_identifier: ($, previous) => choice(
+      previous,
+      $.semgrep_ellipsis
+    ),
   }
 });

--- a/lang/semgrep-grammars/src/semgrep-c/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c/test/corpus/semgrep.txt
@@ -1,0 +1,296 @@
+================================================================================
+Metavariables
+================================================================================
+
+$VAR = 1;
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expression_statement
+    (assignment_expression
+      (identifier)
+      (number_literal))))
+
+================================================================================
+Metavariable pattern
+================================================================================
+
+__SEMGREP_EXPRESSION $X
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (identifier)))
+
+================================================================================
+Typed metavariable
+================================================================================
+
+int x = (int* $FOO);
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (parenthesized_expression
+        (semgrep_typed_metavar
+          (type_descriptor
+            (primitive_type)
+            (abstract_pointer_declarator))
+          (semgrep_metavar))))))
+
+================================================================================
+Parenthesized typed metavariable in argument
+================================================================================
+
+f((int $X));
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expression_statement
+    (call_expression
+      (identifier)
+      (argument_list
+        (parenthesized_expression
+          (semgrep_typed_metavar
+            (type_descriptor
+              (primitive_type))
+            (semgrep_metavar)))))))
+
+================================================================================
+Deep expression operator
+================================================================================
+
+__SEMGREP_EXPRESSION <... foo($E) ...>
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (deep_ellipsis
+      (call_expression
+        (identifier)
+        (argument_list
+          (identifier))))))
+
+================================================================================
+Ellipsis for expression
+================================================================================
+
+$VAR->$MEMBER = ...;
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expression_statement
+    (assignment_expression
+      (field_expression
+        (identifier)
+        (field_identifier))
+      (semgrep_ellipsis))))
+
+================================================================================
+Call with ellipsis
+================================================================================
+
+foo(1, ..., 3);
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expression_statement
+    (call_expression
+      (identifier)
+      (argument_list
+        (number_literal)
+        (semgrep_ellipsis)
+        (number_literal)))))
+
+================================================================================
+Call pattern
+================================================================================
+
+__SEMGREP_EXPRESSION $FUNC(1, ...)
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (call_expression
+      (identifier)
+      (argument_list
+        (number_literal)
+        (semgrep_ellipsis)))))
+
+================================================================================
+Named ellipsis as argument
+================================================================================
+
+f($...ARGS);
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (expression_statement
+    (call_expression
+      (identifier)
+      (argument_list
+        (semgrep_named_ellipsis)))))
+
+================================================================================
+Named ellipsis as statement
+================================================================================
+
+int main() {
+  $TY $X = $E;
+  $...STUFF;
+  foo();
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list))
+    (compound_statement
+      (declaration
+        (type_identifier)
+        (init_declarator
+          (identifier)
+          (identifier)))
+      (expression_statement
+        (semgrep_named_ellipsis))
+      (expression_statement
+        (call_expression
+          (identifier)
+          (argument_list))))))
+
+================================================================================
+Method chaining
+================================================================================
+
+__SEMGREP_EXPRESSION foo. ... .bar()
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (semgrep_expression
+    (call_expression
+      (field_expression
+        (field_expression
+          (identifier)
+          (semgrep_ellipsis))
+        (field_identifier))
+      (argument_list))))
+
+================================================================================
+Block item ellipsis
+================================================================================
+
+int main(int $X) {
+  ...
+}
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (primitive_type)
+          (identifier))))
+    (compound_statement
+      (semgrep_ellipsis))))
+
+================================================================================
+Top level ellipsis
+================================================================================
+
+int x = 2;
+...
+int y = 3;
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (number_literal)))
+  (semgrep_ellipsis)
+  (declaration
+    (primitive_type)
+    (init_declarator
+      (identifier)
+      (number_literal))))
+
+================================================================================
+Variadic parameter with ellipsis body
+================================================================================
+
+int m(int $X, ...) { ... }
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (function_definition
+    (primitive_type)
+    (function_declarator
+      (identifier)
+      (parameter_list
+        (parameter_declaration
+          (primitive_type)
+          (identifier))
+        (variadic_parameter)))
+    (compound_statement
+      (semgrep_ellipsis))))
+
+================================================================================
+Struct field ellipsis
+================================================================================
+
+struct $S { $T $F; ... };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (struct_specifier
+    (type_identifier)
+    (field_declaration_list
+      (field_declaration
+        (type_identifier)
+        (field_identifier))
+      (semgrep_ellipsis))))
+
+================================================================================
+Initializer list ellipsis
+================================================================================
+
+$T $X = { .$F = $V, ... };
+
+--------------------------------------------------------------------------------
+
+(translation_unit
+  (declaration
+    (type_identifier)
+    (init_declarator
+      (identifier)
+      (initializer_list
+        (initializer_pair
+          (field_designator
+            (field_identifier))
+          (identifier))
+        (semgrep_ellipsis)))))


### PR DESCRIPTION
## Summary

The C Semgrep grammar augmentation at `lang/semgrep-grammars/src/semgrep-c/grammar.js` was a no-op: the `rules` block was fully commented out. As a result, any C pattern using `...` outside a variadic parameter list, deep ellipsis (`<... e ...>`), ellipsis-metavariables (`$...X`), or parenthesized typed metavariables (`(int $X)`) failed to parse. Triage data showed 18 of 30 patterns broken.

This change mirrors the C++ augmentation:

- Adds `semgrep_ellipsis`, `deep_ellipsis`, `semgrep_named_ellipsis`, `semgrep_metavar`, `semgrep_typed_metavar`.
- Wires them into `_expression`, `_block_item`, `_top_level_item`, `_field_declaration_list_item`, `_field_identifier`, and `parenthesized_expression`.
- Adds the `__SEMGREP_EXPRESSION` entry point via `translation_unit`.
- Adds 16 corpus tests.

Downstream release PR: semgrep/semgrep-c#2.

Fixes [LANG-471](https://linear.app/semgrep/issue/LANG-471) (umbrella) and [LANG-473](https://linear.app/semgrep/issue/LANG-473) (parenthesized typed metavariable).

## Test plan

- [x] `tree-sitter generate` succeeds with no unresolved conflicts.
- [x] `tree-sitter test` passes all 93 tests (77 inherited + 16 new semgrep cases).
- [x] Spot-checked reproducers from LANG-471 (e.g. `$F(...);`, `void f() { ... }`, bare `...`, `<... y ...>`, `f($...ARGS);`, `f((int $X));`, `int $F(int $X) { ... }`, `struct $S { $T $F; ... };`, `$T $X = { .$F = $V, ... };`, `foo. ... .bar()`); all parse without ERROR nodes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)