### PR TITLE
fix(dart): bump tree-sitter-dart to upstream master (02e9bb19)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-dart/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-dart/grammar.js
@@ -39,9 +39,12 @@ module.exports = grammar(base_grammar, {
     semgrep_metavariable: $ => /\$[A-Z_][A-Z_0-9]*/,
 
     // Alternate "entry point". Allows parsing a standalone expression.
-    semgrep_expression: ($) => seq("__SEMGREP_EXPRESSION", $.semgrep_pattern),
+    semgrep_expression: ($) => seq("__SEMGREP_EXPRESSION", $._semgrep_pattern),
 
-    semgrep_pattern: $ => choice(
+    // Hidden (leading underscore): the choice node is inlined into
+    // `semgrep_expression`, so the parse tree exposes the inner
+    // expression/statement directly.
+    _semgrep_pattern: $ => choice(
       $._expression,
       $._statement,
     ),


### PR DESCRIPTION
## Summary

Bumps the `lang/semgrep-grammars/src/tree-sitter-dart` submodule from `80e23c07` (May 2023) to `02e9bb19` (May 2026), pulling in 13 upstream commits from `UserNobody14/tree-sitter-dart`. This closes a three-year gap of grammar fixes, adds the recently-merged parser-improvements PR (UserNobody14/tree-sitter-dart#97), and includes the just-merged record-return + leading annotation fix (UserNobody14/tree-sitter-dart#98), bringing the grammar in line with current Dart 3 idioms.

## Pre-existing upstream changes (`80e23c07` → `0fc19c3a`)

- [`#83`](https://github.com/UserNobody14/tree-sitter-dart/pull/83) — Extension type declarations.
- [`#85`](https://github.com/UserNobody14/tree-sitter-dart/pull/85) — `tree-sitter.json` for tree-sitter 0.25.x compat.
- [`#88`](https://github.com/UserNobody14/tree-sitter-dart/pull/88) — Fix memory leak by making `NativeFinalizer` instances static.
- [`#89`](https://github.com/UserNobody14/tree-sitter-dart/pull/89) — `set`/`get` contextual keywords as identifiers.
- [`#90`](https://github.com/UserNobody14/tree-sitter-dart/pull/90) — Improve annotation highlighting.
- [`#91`](https://github.com/UserNobody14/tree-sitter-dart/pull/91) — Fix invalid `tree-sitter.json`.
- [`#92`](https://github.com/UserNobody14/tree-sitter-dart/pull/92) — Additional fixes for using `get`/`set` symbols.
- [`#93`](https://github.com/UserNobody14/tree-sitter-dart/pull/93) — Dart 3.10 dot-shorthand expressions.
- Chores: updated versions, tree-sitter dependency, pubspecs, generated files.

## Merged parser-improvements PR ([`#97`](https://github.com/UserNobody14/tree-sitter-dart/pull/97))

Squash-merged as `6922ad29`. 16 grammar fixes plus one scoped-highlight fix:

1. Empty record literal `()`.
2. Dart 3.10 dot-shorthand in `case` patterns and `const` invocations.
3. `get`/`set` as identifier in `initialized_identifier`.
4. `get`/`set`/`Function` as identifier in assignable expressions.
5. Abstract instance fields and top-level external variables.
6. `get`/`set`/`Function` as label and `operator` as identifier.
7. Empty/null statement (`;`).
8. External instance fields with `final`/`covariant` (`dart:js_interop` extension types).
9. Trailing comma in for-loop update expressions.
10. Full expression on field initializer right-hand side.
11. Null-aware key in map literal entry (Dart 3 null-aware elements).
12. Null-assertion `!` and argument parts within cascade subsections.
13. Built-in identifiers as static external field names (`dart:ffi` Struct conventions).
14. Unnamed library directive (`library;`).
15. Symbol literals with dotted ids and operators (`#a.b.c`, `#+`, `#==`).
16. Single-named-field record literal with trailing comma (`(name: v,)`).
17. Scoped `operator` keyword highlight to `operator_signature` (highlights.scm fix).

## Merged record-return PR ([`#98`](https://github.com/UserNobody14/tree-sitter-dart/pull/98))

Squash-merged as `02e9bb19`. Adds parsing support for `@annotation` followed by a record return type — the `@override (R, T) method() {…}` shape used by Elm-style architecture in Flutter. This was the dominant remaining cause of `PartialParsing` errors in the pub.dev catalog (annotated record-returning methods on classes, extensions, enums, and top-level functions).

## Validation

### Flutter SDK corpus

Generated the artifact locally via the standard flow (`make && make install && cd lang && ./test-lang dart && ./release dart --dry-run`) and tested the regenerated `parse-dart` against a 199-file corpus drawn from [`flutter/flutter@master`](https://github.com/flutter/flutter):

| Corpus | Old grammar (`80e23c07`) | New grammar (`02e9bb19`) |
|---|---|---|
| 199 random `.dart` files from `flutter/flutter@master` (1-30 KB each) | 196 ok / 3 fail | **199 ok / 0 fail** |

The 3 previously-failing files all live inside the Flutter SDK's developer tooling (`dev/bots/`) and exercise Dart 3 pattern matching in `switch` expressions (object patterns with empty parens, qualified constant patterns):

- [`dev/bots/check_tests_cross_imports.dart`](https://github.com/flutter/flutter/blob/master/dev/bots/check_tests_cross_imports.dart) — `switch (this) { _MaterialLibrary() => ..., _CupertinoLibrary() => ..., _OtherLibrary() => ... }`
- [`dev/bots/custom_rules/no_stop_watches.dart`](https://github.com/flutter/flutter/blob/master/dev/bots/custom_rules/no_stop_watches.dart) — `Element() || null`, nested `InterfaceType(element: ...)` object patterns
- [`dev/bots/custom_rules/render_box_intrinsics.dart`](https://github.com/flutter/flutter/blob/master/dev/bots/custom_rules/render_box_intrinsics.dart) — `switch (node.parent) { ... }` object patterns

### pub.dev catalog

Scanned the latest version of each package on pub.dev with the regenerated parser, then re-scanned every previously-failing package against the freshly-built parser to discount stale results:

| metric | result |
|---|---|
| total package-versions scanned | 5,285 |
| fully clean parses | 5,147 (97.4%) |
| `PartialParsing` errors | 56 (1.1%) |
| only non-parse errors (e.g. analysis-time issues) | 82 (1.6%) |

Earlier in this branch's history, the same corpus had ~102 packages with `PartialParsing`. The 17 commits squash-merged in `#97` cleared roughly half of those, with **0 regressions** on the previously-clean control sample at every iteration. The remaining 56 were dominated by `@annotation` + record-return-type methods — addressed by `#98` (squash-merged as `02e9bb19`), which is included in this bump.

## Test plan

- [x] `make && make install` (with the bumped submodule) — clean build
- [x] `cd lang/dart && make clean && make` — codegen produces fresh `parser.c`, `Boilerplate.ml`, `CST.ml`, `Parse.ml`
- [x] `./release dart --dry-run` — staged diff of the artifact (only generated content)
- [x] Regenerated `parse-dart`: 199/199 cleanly parse the Flutter corpus above
- [x] pub.dev validation as detailed above
- [x] Original semgrep "segfault" repro (`: string (* filename *)`) — exits cleanly, no signal
- [ ] CI on this repo
- [ ] Follow-up release commit on `semgrep/semgrep-dart` (gated on r2c admin running `./release dart` for real after this lands)

## Notes for reviewer

- Includes a small fix to `lang/semgrep-grammars/src/semgrep-dart/grammar.js`: hides the `semgrep_pattern` choice rule (rename to `_semgrep_pattern`) so the wrapper grammar's two `Standalone expression` / `Standalone metavariable ellipsis` corpus tests pass as written. The hide is reversed by `ocaml-tree-sitter simplify` before OCaml CST generation, so the downstream artifact and the OCaml mapper are unaffected. With this commit, `tree-sitter test` in the wrapper grammar dir reports 6/6 pass (was 4/6). These two tests failed against the old submodule pin too, so it was a pre-existing issue in the wrapper grammar — separate from the submodule bump but small enough to bundle here.
- The semgrep main repo has companion changes in `languages/dart/generic/Parse_dart_tree_sitter.ml` to handle the new CST shapes, in [semgrep#11678](https://github.com/semgrep/semgrep/pull/11678).