### PR TITLE
Update tree-sitter-python grammar to c5fca1a

### DIFF
--- a/lang/language-variants-0.20.6
+++ b/lang/language-variants-0.20.6
@@ -7,7 +7,6 @@ hcl
 java
 javascript
 lua
-python
 r
 ruby
 rust

--- a/lang/language-variants-0.26.3
+++ b/lang/language-variants-0.26.3
@@ -1,2 +1,3 @@
 php
 php-only
+python

--- a/lang/languages-0.20.6
+++ b/lang/languages-0.20.6
@@ -6,7 +6,6 @@ hcl
 java
 javascript
 lua
-python
 r
 ruby
 rust

--- a/lang/languages-0.26.3
+++ b/lang/languages-0.26.3
@@ -1,1 +1,2 @@
 php
+python


### PR DESCRIPTION
## Summary
- Bumps the `tree-sitter-python` submodule to upstream commit `c5fca1a`
- Updates the language variants/languages files from `0.20.6` to `0.26.3`

## Test plan
- [ ] CI passes