### PR TITLE
bump(c-sharp): update tree-sitter-c-sharp (C# 14 language support)

### DIFF
--- a/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -6,7 +6,10 @@
  *
  */
 
-const standard_grammar = require('tree-sitter-c-sharp/grammar');
+// tree-sitter-c-sharp 0.23.6+ switched grammar.js to ESM (`export default`);
+// older versions used `module.exports`. Handle both shapes.
+const _imported = require('tree-sitter-c-sharp/grammar');
+const standard_grammar = _imported.default || _imported;
 
 module.exports = grammar(standard_grammar, {
   /*
@@ -23,7 +26,7 @@ module.exports = grammar(standard_grammar, {
 
   conflicts: ($, previous) => [
     ...previous,
-    [$._expression, $.parameter]
+    [$.expression, $.parameter]
   ],
 
   rules: {
@@ -37,7 +40,7 @@ module.exports = grammar(standard_grammar, {
     },
 
     // Alternate "entry point". Allows parsing a standalone expression.
-    semgrep_expression: $ => seq('__SEMGREP_EXPRESSION', $._expression),
+    semgrep_expression: $ => seq('__SEMGREP_EXPRESSION', $.expression),
 
     // Metavariables
     identifier: ($, previous) => {
@@ -66,7 +69,7 @@ module.exports = grammar(standard_grammar, {
       );
     },
 
-    _declaration: ($, previous) => {
+    declaration: ($, previous) => {
       return choice(
         ...previous.members,
         $.ellipsis
@@ -75,26 +78,19 @@ module.exports = grammar(standard_grammar, {
 
     // We want ellipses to be interchangeable with namespace member declarations, so
     // we need to add them in to `type_declaration` here.
-    _type_declaration: ($, previous) => {
+    type_declaration: ($, previous) => {
       return choice(
         ...previous.members,
         $.ellipsis
       )
     },
 
-    // We do this because a file scoped namespace declaration is a top-level
-    // thing, but ellipses are more particular. We want ellipses to be used
-    // in conjunction with file scoped namespace declarations.
-    // Unfortunately, in the base grammar, we can either have ellipsis
-    // statements, or a file scoped declaration! That's no good. To play
-    // around the previous grammar, we simply allow what came before to also
-    // occur before a file scoped namespace declaration.
-    file_scoped_namespace_declaration: ($, previous) => {
-      return seq(
-        seq(repeat($.global_statement), repeat($._namespace_member_declaration)),
-        previous,
-      )
-    },
+    // (Older versions of this extension wrapped `file_scoped_namespace_declaration`
+    // to allow a prefix of statements/declarations before it. In the post-C#-14
+    // grammar `compilation_unit` already accepts arbitrary `_top_level_item`s
+    // — including `global_statement` and `_namespace_member_declaration` —
+    // before `file_scoped_namespace_declaration`, so the wrapper is redundant
+    // and now conflicts with `preproc_if_in_top_level`. Removed.)
 
     enum_member_declaration: ($, previous) => choice(
           previous,
@@ -115,7 +111,7 @@ module.exports = grammar(standard_grammar, {
     },
 
     // Expression ellipsis
-    _expression: ($, previous) => {
+    expression: ($, previous) => {
       return choice(
         ...previous.members,
         $.ellipsis,
@@ -127,22 +123,26 @@ module.exports = grammar(standard_grammar, {
 
     // TODO: how to use PREC.DOT from original grammar instead of 18 below?
     member_access_ellipsis_expression : $ => prec(18, seq(
-      field('expression', choice($._expression, $.predefined_type, $._name)),
+      field('expression', choice($.expression, $.predefined_type, $._name)),
       choice('.', '->'),
       $.ellipsis
      )),
 
-    // use syntax similar to a cast_expression, but with metavar
+    // Same shape as cast_expression but with a metavariable in place of the
+    // cast value. We need prec.dynamic > cast_expression's (which is 1) so the
+    // typed_metavariable interpretation wins over an ambiguous parse like
+    // `(List<T> $X)` which can otherwise be read as `parenthesized_expression`
+    // containing the binary chain `List < T > $X`.
     //TODO: use PREC.CAST from original grammar instead of 17 below
-    typed_metavariable: $ => prec.right(17, seq(
+    typed_metavariable: $ => prec.dynamic(2, prec.right(17, seq(
       '(',
-      field('type', $._type),
+      field('type', $.type),
       field('metavar', $._semgrep_metavariable),
       ')',
-    )),
+    ))),
 
     deep_ellipsis: $ => seq(
-      '<...', $._expression, '...>'
+      '<...', $.expression, '...>'
     ),
 
     ellipsis: $ => '...',

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/grammar.js
@@ -141,6 +141,17 @@ module.exports = grammar(standard_grammar, {
       ')',
     ))),
 
+    // Real-world C# code occasionally contains technically-invalid
+    // escape sequences inside string literals (`"\\share\images"` where
+    // `\i` is not one of the spec's recognized escapes). Roslyn rejects
+    // these, but the upstream tree-sitter grammar follows Roslyn and
+    // produces an ERROR node, which then fails semgrep's parse-error
+    // gate. Semgrep is a static analyzer that wants to scan as much
+    // code as it can, so we broaden `escape_sequence` here to accept
+    // any `\<single-char>` after the spec-recognized escapes have had a
+    // chance to match.
+    escape_sequence: ($, previous) => choice(previous, token(/\\./)),
+
     deep_ellipsis: $ => seq(
       '<...', $.expression, '...>'
     ),

--- a/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-c-sharp/test/corpus/semgrep.txt
@@ -27,11 +27,10 @@ class $CLASS {
               (predefined_type)
               (variable_declarator
                 (identifier)
-                (equals_value_clause
-                  (conditional_expression
-                    (identifier)
-                    (identifier)
-                    (identifier)))))))))))
+                (conditional_expression
+                  (identifier)
+                  (identifier)
+                  (identifier))))))))))
 
 ================================================================================
 Ellipsis for expression
@@ -59,14 +58,12 @@ class Foo {
           (expression_statement
             (assignment_expression
               (identifier)
-              (assignment_operator)
               (integer_literal)))
           (expression_statement
             (ellipsis))
           (expression_statement
             (assignment_expression
               (identifier)
-              (assignment_operator)
               (integer_literal))))))))
 
 ================================================================================
@@ -95,14 +92,12 @@ class Foo {
           (expression_statement
             (assignment_expression
               (identifier)
-              (assignment_operator)
               (integer_literal)))
           (expression_statement
             (ellipsis))
           (expression_statement
             (assignment_expression
               (identifier)
-              (assignment_operator)
               (integer_literal))))))))
 
 ================================================================================
@@ -129,7 +124,6 @@ class Foo {
           (expression_statement
             (assignment_expression
               (identifier)
-              (assignment_operator)
               (deep_ellipsis
                 (integer_literal)))))))))
 
@@ -236,7 +230,6 @@ $X = $O.foo(). ... .bar();
     (expression_statement
       (assignment_expression
         (identifier)
-        (assignment_operator)
         (invocation_expression
           (member_access_expression
             (member_access_ellipsis_expression
@@ -389,7 +382,9 @@ namespace $N { };
   (namespace_declaration
     (identifier)
     (declaration_list))
-  (ellipsis))
+  (global_statement
+    (expression_statement
+      (ellipsis))))
 
 ================================================================================
 File scoped namespace declarations and ellipses
@@ -402,9 +397,11 @@ namespace $N;
 --------------------------------------------------------------------------------
 
 (compilation_unit
+  (global_statement
+    (expression_statement
+      (ellipsis)))
   (file_scoped_namespace_declaration
-    (global_statement
-      (expression_statement
-        (ellipsis)))
-    (identifier)
-    (ellipsis)))
+    (identifier))
+  (global_statement
+    (expression_statement
+      (ellipsis))))


### PR DESCRIPTION
## Summary

Bumps the `tree-sitter-c-sharp` submodule from `e1384e2` (May 2024) to `af29416`, the current `tree-sitter/tree-sitter-c-sharp` master tip. The intervening upstream changes include the C# 14 language-support PR (tree-sitter/tree-sitter-c-sharp#429), several internal rule restructurings, the switch from CommonJS to ES modules for `grammar.js`, and the new \`(IDENT) && EXPR\` cast-vs-logical-AND disambiguation (tree-sitter/tree-sitter-c-sharp#430). Both upstream PRs are merged.

After this bump, semgrep-c-sharp grammars cover the full C# 14 surface: extension declarations, partial events/constructors, field-backed properties, compound-assignment operator overloads, simple-lambda parameter modifiers, null-conditional assignment, raw string literals (C# 11), list patterns (C# 11), collection expressions (C# 12), primary constructors, generic attributes, static abstract interface members, \`ref readonly\` parameters, inline arrays, and \`nameof\` with unbound generics.

## semgrep-c-sharp/grammar.js adapters

- The base \`grammar.js\` now uses \`export default grammar(...)\`. Wrap the \`require()\` so the extension handles both shapes:
  \`\`\`js
  const _imported = require('tree-sitter-c-sharp/grammar');
  const standard_grammar = _imported.default || _imported;
  \`\`\`
- Upstream renamed several internal-then-exposed rules: \`_declaration\`, \`_type_declaration\`, and \`_expression\` lost their leading underscores. Updated every reference in the semgrep extension (conflicts list, the \`declaration\`/\`type_declaration\`/\`expression\` overrides, the \`semgrep_expression\` / \`member_access_ellipsis_expression\` / \`typed_metavariable\` / \`deep_ellipsis\` call sites).
- Dropped the \`file_scoped_namespace_declaration\` override. In the post-C#-14 grammar \`compilation_unit\` already accepts arbitrary \`_top_level_item\`s — including \`global_statement\` and \`_namespace_member_declaration\` — in any order before a \`file_scoped_namespace_declaration\`, so the wrapper is redundant. With it in place the parser cannot disambiguate it from \`preproc_if_in_top_level\` and the generator fails with an unresolved conflict.
- \`typed_metavariable\` now wraps \`prec.right(17, ...)\` inside \`prec.dynamic(2, ...)\`. Without the dynamic tiebreaker, \`(List<T> $X)\` parses as \`parenthesized_expression(binary_expression(binary_expression(List, T), $X))\` — the parser reads \`List < T > $X\` as a comparison chain inside parens. Beating \`cast_expression\`'s \`prec.dynamic(1)\` restores the typed-metavariable interpretation.
- Broadened \`escape_sequence\` with an extra \`/\\\\./\` token alternative. Semgrep is a static analyzer that wants to scan real-world C# code (where Windows paths embedded in regular string literals occasionally contain technically-invalid escapes like \`"\\\\share\\images"\`). Roslyn rejects these with \`CS1009\`, but with the upstream strict pattern tree-sitter emits an \`ERROR\` node and semgrep's parse-error gate fails the file entirely. With the broader rule the spec escapes match first, and any \`\\\<other>\` falls into the lenient alternative.

## Test-fixture updates (semgrep-c-sharp/test/corpus/semgrep.txt)

The new base grammar removes/restructures a few nodes that the corpus expected trees had baked in. Each delta is mechanical:

- \`variable_declarator\` no longer wraps the initializer in \`equals_value_clause\` — the new grammar inlines \`('=', \$.expression)\` directly. Dropped the wrapper from the **Metavariables** expected tree.
- \`assignment_expression\` no longer exposes \`assignment_operator\` as a named child. Removed \`(assignment_operator)\` lines from **Ellipsis for expression**, **Ellipsis for statements**, **Deep expression ellipsis**, and **Ellipsis in method chain**.
- **Namespace declarations and ellipses** and **File scoped namespace declarations and ellipses** now produce flat top-level items rather than a wrapped \`file_scoped_namespace_declaration\` (matches the dropped override above).

## Verification

- \`./test-lang c-sharp\` is green: **199/199 corpus tests pass**, ConvexHull.cs parses with 0 errors, and the OCaml CST generator emits no \`Blank\` nodes.
- Downstream \`semgrep-c-sharp\` has been regenerated via \`./release c-sharp\` and is staged on \`AlexLaroche/semgrep-c-sharp@bump/tree-sitter-c-sharp-af29416\`.
- Downstream \`semgrep\` has been adapted to the new CST shape (\`Parse_csharp_tree_sitter.ml\`) and is staged on \`AlexLaroche/semgrep@bump/tree-sitter-c-sharp-af29416\`. \`make test\` is green there: **5490 successful (5431 pass + 59 xfail), 0 failures**, including 50 C#-specific parser fixtures (40 pre-existing + 10 new ones covering primary constructors, C# 14 extensions, raw strings, list patterns, collection expressions, nullable reference types, etc.).

## Test plan

- [x] \`cd lang && ./test-lang c-sharp\` → 199/199 corpus tests pass, parse-examples PASS on ConvexHull.cs, no \`Blank\` nodes.
- [ ] Reviewer to confirm the corpus expected-tree updates match the new tree-sitter-c-sharp v0.27 grammar shape.
- [ ] Reviewer to approve the lenient \`escape_sequence\` extension (or request that we keep the strict spec-conforming form and instead skip the affected fixture downstream).

cc @brandonspark — context: this is the post-resolution of PR #543, rebased onto the now-merged upstream PRs.