### PR TITLE
feat: update tree-sitter-solidity grammar to 048fe68

### DIFF
--- a/lang/language-variants-0.20.8
+++ b/lang/language-variants-0.20.8
@@ -1,3 +1,2 @@
 apex
 r
-solidity

--- a/lang/language-variants-0.26.3
+++ b/lang/language-variants-0.26.3
@@ -6,3 +6,4 @@ php-only
 powershell
 python
 ruby
+solidity

--- a/lang/languages-0.20.8
+++ b/lang/languages-0.20.8
@@ -1,5 +1,4 @@
 r
 sfapex
-solidity
 soql
 sosl

--- a/lang/languages-0.26.3
+++ b/lang/languages-0.26.3
@@ -5,3 +5,4 @@ php
 powershell
 python
 ruby
+solidity

--- a/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
@@ -24,11 +24,10 @@ module.exports = grammar(base_grammar, {
         source_file: ($, previous) => {
           return choice(
             previous,
-            repeat1($._statement),
-            $._expression,
+            repeat1($.statement),
+            $.expression,
             $.constructor_definition,
             $.modifier_definition,
-            $.event_definition,
           );
         },
 
@@ -47,9 +46,9 @@ module.exports = grammar(base_grammar, {
                 ),
             )
         },
-      
+
       // Ellipsis
-        _expression: ($, previous) => {
+        expression: ($, previous) => {
             return choice(
                 previous,
                 $.ellipsis,
@@ -67,10 +66,14 @@ module.exports = grammar(base_grammar, {
           );
         },
 
-       // TODO: how to use PREC.MEMBER from original grammar instead of hardcoded value?
+       // There's no PREC.MEMBER to reuse: the upstream PREC table is a
+       // module-local `const` (not exported) and has no MEMBER entry. The base
+       // grammar's `member_expression` uses `prec.dynamic(1, ...)`, but dynamic
+       // precedence doesn't resolve the static LR conflict this rule creates,
+       // so we need a static `prec` here instead.
        member_ellipsis_expression : $ => prec(1, seq(
             field('object', choice(
-                $._expression,
+                $.expression,
                 $.identifier,
             )),
             '.',
@@ -97,8 +100,7 @@ module.exports = grammar(base_grammar, {
             );
         },
 
-        // typo on name in the original grammar so we must copy the typo
-        event_paramater: ($, previous) => {
+        event_parameter: ($, previous) => {
             return choice(
                previous,
                $.ellipsis
@@ -108,7 +110,7 @@ module.exports = grammar(base_grammar, {
         for_statement: ($, previous) => {
             return choice(
                previous,
-               seq('for', '(', $.ellipsis, ')', $._statement)
+               seq('for', '(', $.ellipsis, ')', $.statement)
             );
         },
 
@@ -119,32 +121,27 @@ module.exports = grammar(base_grammar, {
             );
         },
 
-      //TODO? it would be better to refactor the original grammar with
-      // a enum_member so we don't have to copy-paste the original rule
-      enum_declaration: $ =>  seq(
-            'enum',
-            field("enum_type_name", $.identifier),
+      // Allow ellipsis among the enum values by extending the base
+      // grammar's enum_body rule.
+      enum_body: ($, previous) => seq(
             '{',
-            commaSep($._enum_member),
+            commaSep(choice(
+                alias($.identifier, $.enum_value),
+                $.ellipsis
+            )),
             '}',
-      ),
-      _enum_member: $ => choice(
-          alias($.identifier, $.enum_value),
-          $.ellipsis
       ),
 
       // The actual ellipsis rules
         deep_ellipsis: $ => seq(
-            '<...', $._expression, '...>'
+            '<...', $.expression, '...>'
         ),
 
         ellipsis: $ => '...',
   }
 });
 
-// copy-pasted from the original grammar, because of our copy-paste of enum_declaration
-// once the original grammar is rewritten with a enum_member, we would not need
-// those defs anymore
+// copy-pasted from the original grammar, used by our enum_body override
 function commaSep1(rule) {
     return seq(
         rule,

--- a/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
@@ -43,7 +43,11 @@ for(...) {
 ---
 
 (source_file
-  (for_statement (ellipsis) (block_statement)))
+  (statement
+    (for_statement
+      (ellipsis)
+      (statement
+        (block_statement)))))
 
 =====================================
 Constructor pattern
@@ -57,8 +61,9 @@ constructor (...) {
         (parameter
           (ellipsis))
         (function_body
-          (expression_statement
-            (ellipsis)))))
+          (statement
+            (expression_statement
+              (ellipsis))))))
 
 =====================================
 Modifier pattern
@@ -74,8 +79,9 @@ modifier $M(...) {
         (parameter
           (ellipsis))
         (function_body
-          (expression_statement
-            (ellipsis)))))
+          (statement
+            (expression_statement
+              (ellipsis))))))
 
 =====================================
 Inheritance ellipsis pattern
@@ -107,7 +113,8 @@ enum $X {
 (source_file
       (enum_declaration
         (identifier)
-        (ellipsis)))
+        (enum_body
+          (ellipsis))))
 
 =====================================
 Event pattern
@@ -119,5 +126,5 @@ event $EV(...);
 (source_file
       (event_definition
         (identifier)
-        (event_paramater
+        (event_parameter
           (ellipsis))))


### PR DESCRIPTION
Linear: LANG-207

Bumps the `tree-sitter-solidity` submodule to `048fe68` and updates the semgrep extension grammar to match upstream rule renames.
Solidity moves from the 0.20.8 to the 0.26.3 language list, and the test corpus is updated for the new parse trees. `test-lang solidity` passes end-to-end.

Companion PRs:
* https://github.com/semgrep/semgrep-solidity/pull/4
* https://github.com/semgrep/semgrep-proprietary/pull/6563
* https://github.com/semgrep/semgrep-rules/pull/3997
### Checklist

- [x] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)