### PR TITLE
Unshallowing

### DIFF
--- a/scripts/test_update_grammar.py
+++ b/scripts/test_update_grammar.py
@@ -720,6 +720,41 @@ class UpdateSubmoduleTests(FilesystemTest):
             remote_newer,
         )
 
+    def test_is_shallow_repo_false_for_full_clone(self):
+        # The fixture submodule is a normal (non-shallow) clone.
+        self.assertFalse(ug.is_shallow_repo(self.submodule))
+
+    def test_fetch_unshallows_shallow_submodule(self):
+        # Re-clone the submodule shallow (depth 1) so only the pinned commit
+        # is present, then verify update_submodule unshallows and resolves an
+        # older commit that lies beyond the shallow boundary.
+        import shutil
+
+        shutil.rmtree(self.submodule)
+        # `--no-local` forces the transport path; git otherwise ignores
+        # `--depth` for same-filesystem clones and produces a full clone.
+        subprocess.run(
+            ["git", "-c", "protocol.file.allow=always",
+             "clone", "--no-local", "--depth", "1",
+             str(self.remote), str(self.submodule)],
+            check=True, text=True,
+            stdout=subprocess.PIPE, stderr=subprocess.PIPE,
+        )
+        _git("config", "protocol.file.allow", "always", cwd=self.submodule)
+        self.assertTrue(ug.is_shallow_repo(self.submodule))
+
+        # remote_old precedes remote_new (the shallow HEAD), so it is only
+        # reachable after unshallowing.
+        old, new = ug.update_submodule(
+            self.submodule, self.outer, ref=self.remote_old, fetch=True,
+        )
+        self.assertFalse(ug.is_shallow_repo(self.submodule))
+        self.assertEqual(new, self.remote_old)
+        self.assertEqual(
+            _git("rev-parse", "HEAD", cwd=self.submodule).stdout.strip(),
+            self.remote_old,
+        )
+
     def test_fetch_skipped_when_disabled(self):
         # Add a new commit to remote, but with fetch=False the submodule
         # can't resolve it and update_submodule should fail at rev-parse.

--- a/scripts/update-grammar
+++ b/scripts/update-grammar
@@ -12,7 +12,8 @@ Steps performed by `main()` in order:
 3. Verify the outer repo and the target submodule have clean working
    trees (skipped under `--skip-release`).
 4. Resolve the submodule at lang/semgrep-grammars/src/tree-sitter-<sub>,
-   fetch from origin, and check out the ref passed via --ref.
+   fetch from origin (unshallowing a shallow clone first so any historical
+   ref resolves), and check out the ref passed via --ref.
 5. Create a matching branch `$USER/update-<lang>-<short-sha>` in both
    the outer repo and the submodule (so `git push --recurse-submodules`
    finds a matching ref, and so the file edits below land on the branch
@@ -383,6 +384,19 @@ def parse_args(version_choices: Collection[str],
     return parser.parse_args(argv)
 
 
+def is_shallow_repo(repo: Path) -> bool:
+    """Return True if `repo` is a shallow clone.
+
+    Submodules are usually cloned shallow, which leaves arbitrary historical
+    refs unresolvable. `git rev-parse --is-shallow-repository` prints
+    'true'/'false' (available since git 2.15).
+    """
+    return run(
+        ["git", "rev-parse", "--is-shallow-repository"],
+        cwd=repo, capture=True,
+    ).stdout.strip() == "true"
+
+
 def update_submodule(submodule: Path, root: Path, ref: str,
                      fetch: bool) -> tuple[str, str]:
     """Check out `ref` in the submodule. Returns (old_sha, new_sha)."""
@@ -391,6 +405,11 @@ def update_submodule(submodule: Path, root: Path, ref: str,
     ).stdout.strip()
 
     if fetch:
+        # Convert a shallow submodule clone to a full one so any historical
+        # `ref` (old tags, distant commits) resolves. `--unshallow` errors on
+        # an already-complete repo, so only run it when actually shallow.
+        if is_shallow_repo(submodule):
+            run(["git", "fetch", "origin", "--unshallow"], cwd=submodule)
         run(["git", "fetch", "--tags", "origin"], cwd=submodule)
 
     new_sha = run(


### PR DESCRIPTION
### Checklist

- [x] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)