### PR TITLE
Pin dart to tree-sitter 0.26.3

### DIFF
--- a/lang/language-variants-0.22.6
+++ b/lang/language-variants-0.22.6
@@ -6,7 +6,6 @@ cairo
 circom
 clojure
 cpp
-dart
 dockerfile
 elixir
 go

--- a/lang/language-variants-0.26.3
+++ b/lang/language-variants-0.26.3
@@ -1,3 +1,4 @@
+dart
 fga
 gosu
 php

--- a/lang/languages-0.22.6
+++ b/lang/languages-0.22.6
@@ -6,7 +6,6 @@ cairo
 circom
 clojure
 cpp
-dart
 dockerfile
 elixir
 go

--- a/lang/languages-0.26.3
+++ b/lang/languages-0.26.3
@@ -1,3 +1,4 @@
+dart
 fga
 gosu
 php


### PR DESCRIPTION
When running `lang/test-lang dart`, the tests were failing when building with tree-sitter 0.22.6. However, the tests pass if we rebuild it with tree-sitter 0.26.3.

Related PRs: https://github.com/semgrep/semgrep-dart/pull/2

### Checklist

- [ ] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)