### PR TITLE
lang: fix c-sharp-pro fyi.list to reference its own submodule

### DIFF
--- a/lang/c-sharp-pro/fyi.list
+++ b/lang/c-sharp-pro/fyi.list
@@ -1,3 +1,3 @@
-semgrep-grammars/src/tree-sitter-c-sharp/LICENSE
-semgrep-grammars/src/tree-sitter-c-sharp/grammar.js
-semgrep-grammars/src/semgrep-c-sharp/grammar.js
+semgrep-grammars/src/tree-sitter-c-sharp-pro/LICENSE
+semgrep-grammars/src/tree-sitter-c-sharp-pro/grammar.js
+semgrep-grammars/src/semgrep-c-sharp-pro/grammar.js


### PR DESCRIPTION
## Summary
- `lang/c-sharp-pro/fyi.list` was a byte-for-byte copy of `lang/c-sharp/fyi.list`, listing `tree-sitter-c-sharp` paths instead of the separately-pinned `tree-sitter-c-sharp-pro` submodule.
- `lang/semgrep-grammars/src/semgrep-c-sharp-pro/prep` actually reads from `tree-sitter-c-sharp-pro` during generation, so anything scoped by `fyi.list` (attribution file copying in `lang/release`, and submodule drift detection) was silently checking the wrong submodule for this language.

## Test plan
- [x] Verified the corrected paths (`tree-sitter-c-sharp-pro/LICENSE`, `tree-sitter-c-sharp-pro/grammar.js`, `semgrep-c-sharp-pro/grammar.js`) exist on disk.
- [ ] CI passes.