### PR TITLE
Add fix-semgrep-grammar agent skill; fix semgrep-javascript bare '>' in JSX

### DIFF
--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -32,7 +32,7 @@ extension grammar and its tests.**
 - **Repo root** — `git rev-parse --show-toplevel`. Never hardcode an absolute path.
 - **(optional) `max-iterations`** — caps the loop; default **20**. One
   iteration = one step-8 fix plus its step-5 re-run (the step-3 baseline run
-  doesn't count; the step-4 rename batch counts as one; step-8 inner-loop
+  doesn't count; the step-4 rename batch counts as one; step-9 pre-check
   refinements are part of their fix). The default is a
   guess, not empirical; the cap exists to stop runaway loops, not to be
   approached. Reaching it is a normal, logical stop (see Exit contract).
@@ -141,22 +141,24 @@ extension grammar and its tests.**
    substitutions (step 4), and a new/changed rule override carries its corpus
    case (coverage invariant, Edit boundaries).
 
-   **Refine the fix in a fast inner loop before the outer run.** A `test-lang`
-   cycle cleans and rebuilds everything (parser, OCaml codegen and compile,
-   every example file — minutes); `make` in `semgrep-<lang>/` regenerates just
-   the parser (seconds). Iterate there until the fix is locally green:
-   `make` catches generate errors, `core/tree-sitter-<v>/bin/tree-sitter test`
-   runs the corpus, and `... tree-sitter parse <file>` prints the actual tree
-   — both for writing corpus expectations and for checking a failing example
-   file directly. If a few inner attempts haven't gone green, stop tweaking
-   and return to step 7: that's misdiagnosis, not bad luck. The inner loop
-   never replaces the outer run — only `test-lang` (step 9) validates the
+9. **Fix validity pre-check** — `make` in
+   `semgrep-<lang>/` regenerates just the parser, which is much faster than
+   another iteration. Iterate there until the fix is locally green:
+
+   9.1. `make` catches generate errors.
+   9.2. `core/tree-sitter-<v>/bin/tree-sitter test` runs the corpus.
+   9.3. `tree-sitter parse <file>` prints the actual tree — both for writing
+        corpus expectations and for checking a failing example file directly.
+
+   If a few inner attempts haven't gone green, stop tweaking
+   and return to step 7: that's misdiagnosis, not bad luck. The pre-check
+   never replaces the outer run — only `test-lang` (step 10) validates the
    OCaml build, the example sweep, and the Blank check.
 
-9. **Re-run** step 5. Repeat until exit 0, or until `max-iterations` is spent —
-   whichever comes first. Hitting the cap is a normal stop: go to Exit.
+10. **Re-run** step 5. Repeat until exit 0, or until `max-iterations` is spent —
+    whichever comes first. Hitting the cap is a normal stop: go to Exit.
 
-10. **Exit** per the contract below.
+11. **Exit** per the contract below.
 
 ## Edit boundaries
 

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -17,7 +17,7 @@ pattern constructs — ellipsis `...`, metavariables `$X`, deep ellipsis
 `<... e ...>`, typed/variadic metavariables, alternate entry points, and
 friends — in `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`, via
 `($, previous) => ...` rule overrides. Rule names vary per language; the full
-name inventory is in [references/semgrep-constructs.md](references/semgrep-constructs.md).
+name inventory is in `doc/semgrep-constructs.md` at the repo root.
 When upstream changes, the extension stops matching and `test-lang` fails.
 **Make `test-lang <lang>` pass with the smallest correct change to the
 extension grammar and its tests.**

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -12,179 +12,141 @@ description: >-
 
 # Fix the Semgrep grammar (step 4)
 
-This repo extends each upstream `tree-sitter-<lang>` grammar with the Semgrep
-pattern constructs below, in `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`,
-via `($, previous) => ...` rule overrides. When upstream changes, the extension
-stops matching and `test-lang` fails. **Make `test-lang <lang>` pass with the
-smallest correct change to the extension grammar and its tests.**
-
-The semgrep constructs to recognize and preserve (rule names vary per language —
-this is the full family seen across the wrappers):
-
-- **Ellipsis** `...` — `ellipsis` / `semgrep_ellipsis`; spliced in as a statement,
-  expression, parameter/argument, and list element (e.g. `catch_ellipsis`,
-  `semgrep_ellipsis_and_comma`, `semgrep_ellipsis_followed_by_newline`).
-- **Named ellipsis** — `semgrep_named_ellipsis`.
-- **Deep ellipsis** `<... e ...>` — `deep_ellipsis` / `semgrep_deep_ellipsis` /
-  `semgrep_deep_expression`.
-- **Metavariables** `$X` — `_semgrep_metavariable` / `semgrep_metavariable`,
-  usually folded into the base `identifier` rule.
-- **Typed metavariables** `(T $X)` — `typed_metavariable` / `semgrep_typed_metavar`
-  (+ `typed_metavariable_declaration`).
-- **Variadic / ellipsis metavariables** `$...X` — `semgrep_variadic_metavariable` /
-  `semgrep_ellipsis_metavariable` / `_semgrep_metavar_ellipsis`.
-- **Member-/field-access ellipsis** `x. ...` — `member_access_ellipsis_expression`
-  / `member_ellipsis_expression` / `field_access_ellipsis_expr`.
-- **Metavariable assignment** `$X = ...`, `$X += ...` — `semgrep_metavar_eq` /
-  `semgrep_metavar_pluseq` (+ `semgrep_val_or_var_definition`).
-- **Alternate entry points** letting a pattern be a bare fragment —
-  `semgrep_expression` / `semgrep_statement` / `semgrep_pattern` /
-  `semgrep_partial`, added to the grammar's start rule (sometimes guarded by a
-  `__SEMGREP_*` token).
+This repo extends each upstream `tree-sitter-<lang>` grammar with semgrep
+pattern constructs — ellipsis `...`, metavariables `$X`, deep ellipsis
+`<... e ...>`, typed/variadic metavariables, alternate entry points, and
+friends — in `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`, via
+`($, previous) => ...` rule overrides. Rule names vary per language; the full
+name inventory is in [references/semgrep-constructs.md](references/semgrep-constructs.md).
+When upstream changes, the extension stops matching and `test-lang` fails.
+**Make `test-lang <lang>` pass with the smallest correct change to the
+extension grammar and its tests.**
 
 ## Inputs
 
-- **`<lang>`** — the `test-lang` argument (e.g. `javascript`, `solidity`). Some
-  languages build a different sublanguage set under `lang/`: `typescript`→
-  `typescript tsx`, `php`→`php php-only`, `sfapex`→`apex` (**not** `sfapex`),
-  `cfml`→`cfml`. `test-lang` computes this; steps 1 and 4 act on whichever
-  directories it actually builds, not necessarily `lang/<lang>` itself.
-- **Repo root** — `git rev-parse --show-toplevel`; accept a caller override. Never
-  hardcode an absolute path.
-- **(optional) `max-iterations`** — caps the fix/re-run loop (step 8). Default
-  **8** if not given. Enforced by the skill itself — unlike the Budget hint
-  below, reaching it is a normal, logical stop (see Exit contract).
-- **(optional) Budget hint** — advisory only. Bias toward landing a minimal fix and
-  stopping. You cannot enforce time/turn/cost limits; the harness owns those.
+- **`<lang>`** — the `test-lang` argument (e.g. `javascript`, `solidity`). The
+  sublanguage set it builds is hardcoded in the `sublangs=` block of
+  `lang/test-lang` — read it there (currently `typescript`→`typescript tsx`,
+  `php`→`php php-only`, `sfapex`→`apex`, `cfml`→`cfml`, everything else → the
+  lang itself). Steps 1 and 4 act on whichever directories it builds.
+- **Repo root** — `git rev-parse --show-toplevel`. Never hardcode an absolute path.
+- **(optional) `max-iterations`** — caps the loop; default **20**. One
+  iteration = one step-7 fix plus its step-4 re-run (the initial baseline run
+  doesn't count; the step-3 rename batch counts as one). The default is a
+  guess, not empirical — the worst run measured so far (Solidity) needed ~6
+  fixes; the cap exists to stop runaway loops, not to be approached. Reaching
+  it is a normal, logical stop (see Exit contract).
+- **(optional) Budget hint** — advisory only; bias toward landing a minimal fix
+  and stopping. The harness owns hard time/turn/cost limits.
 
 ## The loop
 
 1. **Check for uncommitted changes** (precondition, from the repo root):
    ```
-   git status --porcelain -- lang/semgrep-grammars/src/semgrep-<lang> lang/<sublang-1> lang/<sublang-2> ...
+   git status --porcelain --ignored -- lang/semgrep-grammars/src/semgrep-<lang> lang/<sublang-1> lang/<sublang-2> ...
    ```
-   using the sublanguage set from Inputs (usually just `<lang>` itself — see
-   the exceptions there, e.g. `sfapex` needs `lang/apex`, not `lang/sfapex`).
-   `test-lang` runs `make clean` in every one of these directories on
-   **every** iteration of this loop (step 4), and `make clean` there is `git
-   clean -dfX` — it force-deletes every git-ignored file under that tree, no
-   confirmation, no matter what's actually in it. In this repo that's
-   normally just regenerable build output (`src/`, `test.log`, `CST.ml`,
-   `ocaml-src`, …), but the skill has no way to verify that's still true for
-   an arbitrary `<lang>`, or whether the user left something there they care
-   about. If `git status --porcelain` reports anything under any of these
-   paths (tracked changes *or* untracked-but-ignored files), **stop and tell
-   the user exactly what `git clean -dfX` would remove, and ask them to
-   confirm before proceeding.** Don't assume it's disposable. A clean tree
-   needs no confirmation.
+   using the sublanguage set from Inputs (`--ignored` matters — plain status
+   won't list the ignored files `git clean -dfX` deletes). `test-lang` runs
+   `make clean` in each of these directories on every iteration, and `make
+   clean` there is `git clean -dfX`: it force-deletes every git-ignored file
+   under the tree, no confirmation. Normally that's regenerable build output
+   (`src/`, `test.log`, `CST.ml`, `ocaml-src`, …), but don't assume. If the
+   status reports anything — tracked changes *or* untracked/ignored files —
+   **stop, list exactly what `git clean -dfX` would remove (noting which files
+   are recognizably generated: generated-file headers, standard artifact
+   names), and ask the user to confirm.** A clean tree needs no confirmation.
 
-2. **Require the toolchain** (precondition, from the repo root). The tree-sitter
-   version for `<lang>` is pinned in `lang/languages-*`. Verify it is installed; if
-   not, stop with `CANNOT_PROCEED` — provisioning it is the harness's job, not this
-   skill's (installing mutates shared `core/` state):
+2. **Require the toolchain** (precondition, from the repo root). The
+   tree-sitter version for `<lang>` is pinned in `lang/languages-*`; verify it,
+   never install it (installing mutates shared `core/` state — that's the
+   harness's job):
    ```
    v=$(lang/scripts/ts-version-for-lang <lang>)
    [ -x core/tree-sitter-$v/bin/tree-sitter ] || \
      { echo "tree-sitter $v is not installed for <lang> — cannot proceed"; exit 1; }
    ```
-   Report the missing version and the install command the harness should run:
-   `cd core && ./scripts/switch-tree-sitter-version <v> && ./scripts/install-tree-sitter-cli && ./scripts/install-tree-sitter-lib`.
+   If missing, stop with `CANNOT_PROCEED`, reporting the version and the
+   install command for the harness to run: `cd core &&
+   ./scripts/switch-tree-sitter-version <v> && ./scripts/install-tree-sitter-cli
+   && ./scripts/install-tree-sitter-lib`.
 
-3. **Statically pre-diagnose generate-time breakage, once, before the first
-   run** (from the repo root). `tree-sitter generate` reports only the first
-   broken reference per invocation — it cannot reveal a second broken
-   override until the first is fixed and regenerated, which otherwise forces
-   one full iteration of this loop per rename just to discover the next one.
-   Front-load whatever's discoverable by name before that happens:
+3. **Statically pre-diagnose broken references, once, before the first run.**
+   `tree-sitter generate` reports only the first broken reference per
+   invocation, so find them all by name up front:
    ```
    grep -oE '\$\.\w+' lang/semgrep-grammars/src/semgrep-<lang>/grammar.js | sort -u
    ```
-   For each `$.<name>` this finds, check it's still declared in the *current*
-   upstream grammar (adjust for quoted keys / declaration style):
-   ```
-   grep -n "<name>" lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js
-   ```
-   Any override referencing a name that no longer resolves is a candidate
-   rename/promotion — diagnose it the same way as step 6 (match against
-   upstream's *current* definition, check its recent history), just
-   proactively instead of reactively.
+   First discard names the extension itself declares (keys of its own
+   `rules: {}`) — those are self-owned and will never appear upstream. Check
+   each remaining name still resolves in the *current*
+   `lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js` (adjust for quoted
+   keys / declaration style). Each name that doesn't is a candidate
+   rename/promotion — diagnose it per step 6, proactively. Apply the verified
+   rename queue as a **single batched fix** — renames are one fix class and
+   `generate` validates them together; everything else stays one fix per
+   iteration (step 7).
 
-   **A rename found this way needs two edits, not one.** Renaming `<old>` to
-   `<new>` in `grammar.js` fixes `generate`, but any semgrep-owned corpus case
-   whose expected S-expression names `<old>` (e.g. `(<old> ...)`) will then
-   fail `tree-sitter test` on the very next run — that text doesn't update
-   itself. Before running `test-lang` for the first time, also:
+   A rename fix has two parts, applied together as one edit: the `grammar.js`
+   reference *and* every semgrep-owned corpus case naming the old node:
    ```
    grep -rn "(<old>" lang/semgrep-grammars/src/semgrep-<lang>/test/corpus/*.txt
    ```
-   (never `test/corpus/inherited` — that's upstream's own corpus and already
-   matches upstream's rename) and batch-substitute `<old>`→`<new>` in every
-   hit. Treat this as a **draft**, not a confirmed fix: a rename upstream
-   isn't guaranteed to be *pure* — the shape or fields around it can change
-   too — so these substitutions still need verifying against the actual
-   output tree once `test-lang` runs, same as any other corpus update (see
-   "Corpus tree drifted" in the Fix playbook). Batch every `grammar.js` and
-   corpus fix this pass finds into a single edit before running `test-lang`
-   for the first time.
-
-   This is a heuristic first pass, not a substitute for step 6 or 5: it only
-   catches breakage that shows up as "this exact name no longer exists," and
-   its corpus substitutions are provisional until verified. It won't catch
-   new conflicts, corpus drift from a non-rename cause, or a symbol that
-   still resolves but now means something different — those still only
-   surface once you actually run `test-lang`, in step 4.
+   (never `test/corpus/inherited` — that's upstream's own corpus). Corpus
+   substitutions are drafts until verified against actual output once
+   `test-lang` runs — an upstream rename isn't guaranteed pure. This pass only
+   catches "this name no longer exists"; conflicts, corpus drift, and symbols
+   that still resolve but changed meaning surface only in step 4.
 
 4. **Run** (from the `lang/` dir, not the repo root):
    ```
    cd lang && ./test-lang <lang>
    ```
-   It runs, in order: (a) build + `tree-sitter test` corpus tests in
-   `semgrep-grammars/src/semgrep-<lang>/`, then (b) `parse-examples` for each
-   sublang — the generated parser run over real files in
-   `lang/<sublang>/test/{ok,xfail}` — then (c) a Blank-node check per sublang
-   (see below). `semgrep-grammars/src/semgrep-<lang>/` and every sublang
-   directory are each `make clean`'d (`git clean -dfX` — see step 1) before
-   being rebuilt. Success = **exit code 0** (no unexpected results) **and no
-   new Blank-node warnings** (see baseline, below).
+   In order: (a) build + `tree-sitter test` corpus tests in
+   `semgrep-grammars/src/semgrep-<lang>/`, (b) `parse-examples` per sublang —
+   the generated parser over real files in `lang/<sublang>/test/{ok,xfail}` —
+   (c) a Blank-node check per sublang. Each directory is `git clean -dfX`'d
+   first (step 1). Success = **exit code 0 and no new Blank-node warnings vs.
+   the baseline**.
 
-   **Blank-node baseline:** `test-lang`'s Blank-node check (per sublang, grep
-   for `Blank` in `ocaml-src/lib/CST.ml`) is advisory — it never affects
-   `test-lang`'s own exit code. The **first time you run step 4, before any
-   edit from step 7**, record whatever Blank-node warnings it prints as the
-   **baseline**: pre-existing Blank nodes are not this run's problem to fix,
-   and fixing one anyway would violate "smallest correct edit." If that first
-   run fails before reaching the Blank-node check (e.g. a `tree-sitter
-   generate` or corpus error upstream of it), treat the baseline as
-   unknown/empty for that sublang and say so in the exit summary — don't
-   assume it's clean. On every later run, compare the warnings against the
-   baseline: only *new* ones (not present at baseline) count against
-   `SUCCESS`.
+   **Blank-node baseline:** the check greps generated `ocaml-src/lib/CST.ml`,
+   so it can only report on a run that builds far enough to produce that file;
+   it is advisory and never affects `test-lang`'s exit code. If the **first**
+   run (before any edit) reaches the check for a sublang, its warnings are
+   that sublang's baseline — those pre-existing Blank nodes are out of scope,
+   and fixing one would violate "smallest correct edit". If the first run
+   fails before the check, the baseline is **empty**: `SUCCESS` then requires
+   no Blank-node warnings at all. On later runs, only warnings not in the
+   baseline count against `SUCCESS`.
 
 5. **Classify** the first failure:
 
    | Symptom | Meaning |
    |---|---|
-   | `tree-sitter generate` errors | grammar.js references a rule upstream renamed/removed, or overrides create an unresolved conflict (error names the rule) |
-   | corpus test diff (expected vs actual S-expr) | a `test/corpus/*.txt` expected tree no longer matches a legitimate upstream change |
-   | example in `test.out/fail.list` (CST dumped to `test.out/**/<file>.cst`, look for `!ERROR!`/`ERROR`) | a real source file no longer parses |
-   | Blank-node warning **not in the step-4 baseline** | a node your edit introduced or exposed produces no tokens — give it a named rule |
+   | `tree-sitter generate` errors | grammar.js references a rule upstream renamed/removed, or the overrides create an unresolved conflict (the error names the rule) |
+   | corpus test diff (expected vs actual S-expr) | expected tree ≠ actual — either a legitimate upstream change or a regression from your own earlier edit; step 6 decides which |
+   | example in `test.out/fail.list` — entries are paths relative to `lang/<sublang>/test/ok/`; each CST dump is at `test.out/ok/<entry>.cst` (look for `!ERROR!`/`ERROR`) | a real source file no longer parses |
+   | Blank-node warning not in the baseline | a node your edit introduced or exposed produces no tokens — give it a named rule |
+   | tree-sitter version/ABI errors (grammar needs a newer tree-sitter than the pin, ABI mismatch) | the `lang/languages-*` pin is stale, not a grammar bug — out of scope: `CANNOT_PROCEED`, reporting the version-list change needed |
 
-   A Blank-node warning that *was already in the baseline* is pre-existing and
-   out of scope for this run — leave it alone.
+6. **Diagnose against upstream** — match each rule you override to its
+   *current* definition in `lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js`
+   and check what changed:
+   `git -C lang/semgrep-grammars/src/tree-sitter-<lang> log --oneline -5`.
+   For example failures, the `.cst` dump shows which node became `ERROR`.
+   Don't guess.
 
-6. **Diagnose against upstream** — match each rule you override to its *current*
-   upstream definition; don't guess. Read
-   `lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js` for the named rule and
-   check what changed: `git -C lang/semgrep-grammars/src/tree-sitter-<lang> log --oneline -5`.
-   For example failures, the `.cst` dump shows exactly which node became `ERROR`.
+7. **Apply the smallest correct edit** (playbook below), one logical fix at a
+   time — the sole exception is the step-3 rename queue, which lands as one
+   batched fix. A fix includes its corpus updates: a rename carries its corpus
+   substitutions (step 3), and a new/changed rule override carries its corpus
+   case (coverage invariant, Edit boundaries). To derive and verify a corpus
+   expectation without burning an iteration: `make` in `semgrep-<lang>/`, then
+   `core/tree-sitter-<v>/bin/tree-sitter parse <snippet>` for the actual tree
+   and `tree-sitter test --include '<case name>'` for the case — then re-run
+   `test-lang` to confirm end to end.
 
-7. **Apply the smallest correct edit** (playbook below). Change one thing at a
-   time. If the edit adds or changes a rule override, add or extend its corpus
-   case in the same step — see the coverage invariant under Edit boundaries.
-
-8. **Re-run** step 4. Repeat until exit 0, or until `max-iterations` attempts
-   (default **8**) are spent — whichever comes first. Hitting the cap is a
-   normal, logical stop, not a failure to paper over: go to Exit.
+8. **Re-run** step 4. Repeat until exit 0, or until `max-iterations` is spent —
+   whichever comes first. Hitting the cap is a normal stop: go to Exit.
 
 9. **Exit** per the contract below.
 
@@ -192,31 +154,32 @@ this is the full family seen across the wrappers):
 
 **May edit (only these):**
 - `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`
-- semgrep-owned corpus files `lang/semgrep-grammars/src/semgrep-<lang>/test/corpus/*.txt` — **never** the `inherited` symlink (it points at the upstream corpus).
+- semgrep-owned corpus files `lang/semgrep-grammars/src/semgrep-<lang>/test/corpus/*.txt`
+  — **never** the `inherited` symlink (it points at the upstream corpus). If no
+  semgrep-owned file exists yet, create `test/corpus/semgrep.txt`; match the
+  inherited corpus's S-expression style (e.g. no field names).
 
-**Coverage invariant: every rule override in `grammar.js` — every key in the
-`rules: {}` object — must be exercised by at least one case in the
-semgrep-owned corpus.** `test-lang`'s `parse-examples` step only asserts that
-a file parses without an `ERROR`/`MISSING` node (an exit-code check on the
-whole file); it does not assert *what* tree comes out. A corpus case is the
-only thing in this toolchain that pins the exact expected S-expression, so
-it's the only thing that catches "still parses, but the shape changed"
-regressions. When you add or change a rule override, add or extend its corpus
-case in the same edit — don't defer it, and don't rely on an incidental
-`test/ok` example file being enough (it wasn't written to protect this rule
-and can be moved/pruned without anyone noticing the coverage went with it).
+**Coverage invariant: every rule override you add or change must be exercised
+by at least one semgrep-owned corpus case, added or extended in the same
+edit.** A corpus case is the only test that pins the exact S-expression
+(`parse-examples` only checks that a file parses without `ERROR`/`MISSING`),
+so it's the only thing that catches "still parses, but the shape changed".
+Don't defer the case, and don't count an incidental `test/ok` example as
+coverage. Pre-existing overrides that lack coverage are out of scope — don't
+backfill them; list them in the exit summary for a human to triage.
 
-**Never edit:** `tree-sitter-<lang>/` (the submodule, including `scanner.c`); the
-`lang/languages-*` / `language-variants-*` version lists or the submodule pointer;
-anything in the CST→AST / OCaml codegen or the `semgrep` proprietary repo; the
-`inherited` corpus symlink.
+**Never edit:** `tree-sitter-<lang>/` (the submodule, including `scanner.c`);
+the `lang/languages-*` / `language-variants-*` version lists or the submodule
+pointer; anything in the CST→AST / OCaml codegen or the `semgrep` proprietary
+repo; the `inherited` corpus symlink.
 
-**Never weaken semgrep semantics or tests to go green.** Specifically: never
-delete, skip, or relocate a test (e.g. moving an example to `test/xfail/`) to make
-the run pass artificially; never delete a semgrep construct; never rewrite an
-expected corpus tree just to silence a failure. Expected trees change only to
-reflect a *legitimate* upstream structural change. A case you cannot make pass with
-a legitimate grammar change is `CANNOT_PROCEED` (see Exit) — not a test you remove.
+**Never weaken semgrep semantics or tests to go green.** Never delete, skip,
+or relocate a test (e.g. into `test/xfail/`); never delete a semgrep
+construct; never rewrite an expected corpus tree just to silence a failure —
+expected trees change only to reflect a *legitimate* upstream structural
+change. A case you cannot make pass with a legitimate grammar change is
+`CANNOT_PROCEED` (see Exit) — unless upstream deliberately dropped the syntax,
+in which case ask the user first (see the playbook's last entry).
 
 ## Fix playbook
 
@@ -225,81 +188,82 @@ Common shapes when an upstream bump breaks the extension:
 - **Rule renamed upstream** → update every reference (often a `_` added/dropped:
   `_statement`↔`statement`; or a typo fix: `event_paramater`→`event_parameter`).
 - **Rule promoted to a top-level upstream declaration** → your override now
-  double-defines it (generate conflict); drop the redundant entry.
-- **You copy-pasted a base rule to splice in ellipsis, and upstream refactored it**
-  → stop copying; extend the new upstream rule with `($, previous) =>`. Delete
-  orphaned copied helpers.
-- **Corpus tree drifted** from a legitimate upstream change → update the expected
-  S-expr in `test/corpus/*.txt` to match; verify against the actual tree, don't
-  blindly paste.
-- **Stale `// TODO: use PREC.X`** for a constant that isn't exported → if you must
-  hardcode a precedence, replace the TODO with the one-line reason.
+  makes it reachable twice (generate conflict); drop the redundant entry. In
+  an entry-point override, check each alternative individually — drop only
+  the ones upstream now makes reachable; the rest must stay.
+- **You copy-pasted a base rule to splice in ellipsis, and upstream refactored
+  it** → stop copying; extend the new upstream rule with `($, previous) =>`.
+  Delete orphaned copied helpers.
+- **Corpus tree drifted** from a legitimate upstream change → update the
+  expected S-expr in `test/corpus/*.txt` to match; verify against the actual
+  tree, don't blindly paste.
+- **Stale `// TODO: use PREC.X`** for a constant that isn't exported → don't
+  re-investigate: upstream `PREC` tables are module-local `const`s the
+  extension can never reference, and `prec.dynamic` doesn't resolve a static
+  LR conflict. If you must hardcode a precedence, replace the TODO with the
+  one-line reason.
 - **New parse conflict** (generate error names two rules, not a missing one) →
-  resolve it in the extension grammar with the most specific `prec`/`prec.dynamic`
-  or `conflicts: [...]` entry that works; don't restate upstream rules to dodge it.
-- **Failure traces to an external token** — one listed in upstream's `externals:`
-  array and produced by `scanner.c` → the real fix lives in the scanner, which is
-  out of scope: `CANNOT_PROCEED`, naming the token.
+  resolve it in the extension grammar with the most specific
+  `prec`/`prec.dynamic` or `conflicts: [...]` entry that works; don't restate
+  upstream rules to dodge it.
+- **Failure traces to an external token** — one listed in upstream's
+  `externals:` array and produced by `scanner.c` → first check whether
+  extending a rule in `grammar.js` can route around it (semgrep-javascript's
+  `_jsx_child` works around a scanner limitation in-bounds); if the fix truly
+  requires scanner changes, `CANNOT_PROCEED`, naming the token.
 - **Upstream changed the `word:`/identifier token** → metavariables folded into
-  `identifier` may stop lexing; re-fold them against the new identifier rule. If
-  `$X` can no longer be admitted without scanner changes, `CANNOT_PROCEED`.
+  `identifier` may stop lexing; re-fold them against the new identifier rule.
+  If `$X` can no longer be admitted without scanner changes, `CANNOT_PROCEED`.
 - **New upstream syntax collides with a semgrep construct** (e.g. upstream adds
   real `...` or `$`-prefixed names) → try precedence/token ordering so both
   survive; if the construct can't be disambiguated without weakening it,
   `CANNOT_PROCEED`.
-- **Upstream restructured its grammar file layout** (e.g. a dialect factory like
-  `common/define-grammar.js`) → update the extension's `require(...)`/wrapping to
-  the new entry point; the rule overrides themselves may need no change.
-- **Upstream deliberately dropped syntax**, so a `test/ok` example or corpus case
-  is legitimately no longer parseable → do **not** move it to `xfail`, delete it,
-  or rewrite it on your own: **warn the user, state exactly what upstream dropped
-  and which tests it strands, and ask how to proceed.** If no one can answer
-  (unattended run), exit `CANNOT_PROCEED` with that question as the blocker.
+- **Upstream restructured its grammar file layout** (e.g. a dialect factory
+  like `common/define-grammar.js`) → update the extension's
+  `require(...)`/wrapping to the new entry point; the rule overrides themselves
+  may need no change.
+- **Upstream deliberately dropped syntax**, so a `test/ok` example or corpus
+  case is legitimately no longer parseable → do **not** move it to `xfail`,
+  delete it, or rewrite it on your own: **warn the user, state exactly what
+  upstream dropped and which tests it strands, and ask how to proceed.** If no
+  one can answer (unattended run), exit `CANNOT_PROCEED` with that question as
+  the blocker.
 
-Prefer extending over replacing, and replacing over copy-pasting — the less of the
-upstream rule you restate, the less drifts next time.
+Prefer extending over replacing, and replacing over copy-pasting — the less of
+the upstream rule you restate, the less drifts next time.
 
 ## Exit contract
 
-A **logical** stop, or the `max-iterations` cap (step 8) being reached — never a
-resource cap invented on the fly. Print one unmistakable line:
+A **logical** stop, or the `max-iterations` cap — never a resource cap invented
+on the fly. Print one unmistakable line:
 
-- **`FIX-SEMGREP-GRAMMAR: SUCCESS`** — `test-lang <lang>` exits 0, every rule
-  override in `grammar.js` has a corpus case (the coverage invariant under
-  Edit boundaries), **and** no new Blank-node warnings vs. the step-4 baseline.
-  Summarize the edits (files, fix class, why), which corpus case covers which
-  rule, and the Blank-node baseline you captured, for the PR reviewer.
-- **`FIX-SEMGREP-GRAMMAR: CANNOT_PROCEED`** — no progress for a logical reason: the
-  real fix needs an out-of-scope change (submodule/scanner, translation, version
-  bump), the failure isn't a grammar issue, or fixing it would weaken semgrep
-  semantics. State the blocker, what you tried, and the smallest change that *would*
-  fix it if the boundary were lifted.
-- **`FIX-SEMGREP-GRAMMAR: ITERATION_LIMIT`** — `max-iterations` attempts were spent
-  without reaching exit 0. Summarize every edit tried, the current failure, and your
-  best guess at the next edit, so a human or a fresh run can pick it up.
+- **`FIX-SEMGREP-GRAMMAR: SUCCESS`** — `test-lang <lang>` exits 0, the coverage
+  invariant holds for every override you touched, and no new Blank-node
+  warnings vs. the baseline. Summarize the edits (files, fix class, why),
+  which corpus case covers which touched rule, the baseline you captured, and
+  any pre-existing uncovered overrides you did not backfill, for the PR
+  reviewer.
+- **`FIX-SEMGREP-GRAMMAR: CANNOT_PROCEED`** — no progress for a logical reason:
+  the real fix needs an out-of-scope change (submodule/scanner, translation,
+  version bump), the failure isn't a grammar issue, or fixing it would weaken
+  semgrep semantics. State the blocker, what you tried, and the smallest change
+  that *would* fix it if the boundary were lifted.
+- **`FIX-SEMGREP-GRAMMAR: ITERATION_LIMIT`** — `max-iterations` was spent
+  without reaching exit 0. Summarize every edit tried, the current failure, and
+  your best guess at the next edit, so a human or a fresh run can pick it up.
 
-Do **not** commit, push, or open a PR unless asked. Leave the working tree changed
-for the surrounding grammar-update process's later PR-review stage (a separate,
-outer pipeline from this skill's own numbered steps 1-9 above — the numbering
-isn't shared) to carry into a PR for human review — no auto-merge.
+Do **not** commit, push, or open a PR unless asked. Leave the working tree
+changed for the outer grammar-update pipeline's PR-review stage — no
+auto-merge.
 
 ## Running by hand
 
 From the repo, give the agent the language and this skill, e.g.
-`Use fix-semgrep-grammar to make test-lang javascript pass.` Add a tighter cap if you
-want one, e.g. `... pass, with max-iterations 5.` Under the Claude Agent SDK (e.g. a
-Python GitHub Action), invoke with this skill available and enforce the hard limits
-(`max_turns`, budget, an outer `timeout`) at the harness level — `max-iterations`
-bounds the fix loop itself, not turns/tokens/wall-clock, so keep the harness-level
-limits too.
-
-**Toolchain:** `test-lang` needs the per-language tree-sitter version built. This is
-a **precondition the harness provisions** (via the `core/scripts` installers); the
-skill only verifies it (step 2) and reports `CANNOT_PROCEED` if it's missing — it
-never installs it, and never works around a missing toolchain by editing grammar.js.
-
-**Uncommitted state:** step 1 will stop and ask before letting `test-lang` run
-`git clean -dfX` over any dirty `semgrep-<lang>` or sublang tree it's about to
-rebuild. If running unattended (no one to answer the confirmation), the
-harness should either start from a clean checkout or pre-approve/skip step 1
-explicitly — don't silently auto-confirm on the skill's behalf.
+`Use fix-semgrep-grammar to make test-lang javascript pass.` — optionally with
+a tighter cap, e.g. `... pass, with max-iterations 5.` Under the Claude Agent
+SDK (e.g. a Python GitHub Action), keep the hard limits (`max_turns`, budget,
+an outer `timeout`) at the harness level — `max-iterations` bounds only the fix
+loop. The tree-sitter toolchain is a precondition the harness provisions (step
+2 only verifies it). Unattended runs should start from a clean checkout or
+explicitly pre-approve step 1's confirmation — never silently auto-confirm on
+the skill's behalf.

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -13,11 +13,10 @@ description: >-
 # Fix the Semgrep grammar
 
 This repo extends each upstream `tree-sitter-<lang>` grammar with semgrep
-pattern constructs — ellipsis `...`, metavariables `$X`, deep ellipsis
-`<... e ...>`, typed/variadic metavariables, alternate entry points, and
-friends — in `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`, via
-`($, previous) => ...` rule overrides. Rule names vary per language; the full
-name inventory is in `doc/semgrep-constructs.md` at the repo root.
+pattern constructs (ellipsis `...`, metavariables `$X`, and friends — full
+per-language rule-name inventory in `doc/semgrep-constructs.md`) via
+`($, previous) => ...` rule overrides in
+`lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`.
 When upstream changes, the extension stops matching and `test-lang` fails.
 **Make `test-lang <lang>` pass with the smallest correct change to the
 extension grammar and its tests.**
@@ -26,9 +25,8 @@ extension grammar and its tests.**
 
 - **`<lang>`** — the `test-lang` argument (e.g. `javascript`, `solidity`). The
   sublanguage set it builds is hardcoded in the `sublangs=` block of
-  `lang/test-lang` — read it there (currently `typescript`→`typescript tsx`,
-  `php`→`php php-only`, `sfapex`→`apex`, `cfml`→`cfml`, everything else → the
-  lang itself). Steps 1 and 4 act on whichever directories it builds.
+  `lang/test-lang` — read it there; usually it's just the lang itself. Steps
+  1, 3, and 5 act on whichever directories it builds.
 - **Repo root** — `git rev-parse --show-toplevel`. Never hardcode an absolute path.
 - **(optional) `max-iterations`** — caps the loop; default **20**. One
   iteration = one step-8 fix plus its step-5 re-run (the step-3 baseline run
@@ -53,9 +51,8 @@ extension grammar and its tests.**
    which files look machine-generated), and ask the user to confirm.** A
    clean tree needs no confirmation.
 
-2. **Ensure the toolchain** (from the repo root). Grammar builds are
-   parametrized on the `lang/languages-*` pins; each pinned version lives
-   side by side in `core/tree-sitter-<version>/`:
+2. **Ensure the toolchain** (from the repo root). Pinned tree-sitter versions
+   live side by side in `core/tree-sitter-<version>/`:
    ```
    v=$(lang/scripts/ts-version-for-lang <lang>)
    [ -x core/tree-sitter-$v/bin/tree-sitter ] || make setup-tree-sitter-versions
@@ -106,11 +103,10 @@ extension grammar and its tests.**
    ```
    grep -rn "(<old>" lang/semgrep-grammars/src/semgrep-<lang>/test/corpus/*.txt
    ```
-   (never `test/corpus/inherited` — that's upstream's own corpus). Corpus
-   substitutions are drafts until verified against actual output once
-   `test-lang` runs — an upstream rename isn't guaranteed pure. This pass only
-   catches "this name no longer exists"; conflicts, corpus drift, and symbols
-   that still resolve but changed meaning surface only when `test-lang` runs.
+   (never `test/corpus/inherited` — that's upstream's own corpus). Verify the
+   substitutions against actual output in step 9 — a rename isn't guaranteed
+   pure. This pass only catches dead names; everything else surfaces when
+   `test-lang` runs.
 
 ## The loop
 
@@ -141,19 +137,18 @@ extension grammar and its tests.**
    substitutions (step 4), and a new/changed rule override carries its corpus
    case (coverage invariant, Edit boundaries).
 
-9. **Fix validity pre-check** — `make` in
-   `semgrep-<lang>/` regenerates just the parser, which is much faster than
-   another iteration. Iterate there until the fix is locally green:
+9. **Fix validity pre-check** — iterate inside `semgrep-<lang>/` until the fix
+   is locally green; this rebuilds just the parser, much faster than another
+   iteration:
 
-   9.1. `make` catches generate errors.
-   9.2. `core/tree-sitter-<v>/bin/tree-sitter test` runs the corpus.
-   9.3. `tree-sitter parse <file>` prints the actual tree — both for writing
-        corpus expectations and for checking a failing example file directly.
+   a) `make` — regenerates the parser; catches generation errors.
+   b) `core/tree-sitter-<v>/bin/tree-sitter test` — runs the corpus.
+   c) `tree-sitter parse <file>` — prints the actual tree, for writing corpus
+      expectations and checking a failing example file directly.
 
-   If a few inner attempts haven't gone green, stop tweaking
-   and return to step 7: that's misdiagnosis, not bad luck. The pre-check
-   never replaces the outer run — only `test-lang` (step 10) validates the
-   OCaml build, the example sweep, and the Blank check.
+   If a few attempts haven't gone green, return to step 7: that's
+   misdiagnosis, not bad luck. Only the outer `test-lang` run (step 10)
+   validates the OCaml build, the example sweep, and the Blank check.
 
 10. **Re-run** step 5. Repeat until exit 0, or until `max-iterations` is spent —
     whichever comes first. Hitting the cap is a normal stop: go to Exit.
@@ -207,11 +202,10 @@ Common shapes when an upstream bump breaks the extension:
 - **Corpus tree drifted** from a legitimate upstream change → update the
   expected S-expr in `test/corpus/*.txt` to match; verify against the actual
   tree, don't blindly paste.
-- **Stale `// TODO: use PREC.X`** for a constant that isn't exported → don't
-  re-investigate: upstream `PREC` tables are module-local `const`s the
-  extension can never reference, and `prec.dynamic` doesn't resolve a static
-  LR conflict. If you must hardcode a precedence, replace the TODO with the
-  one-line reason.
+- **Stale `// TODO: use PREC.X`** → don't re-investigate: upstream `PREC`
+  tables are module-local `const`s the extension can never reference, and
+  `prec.dynamic` doesn't resolve a static LR conflict — hardcode the
+  precedence and replace the TODO with the one-line reason.
 - **New parse conflict** (generate error names two rules, not a missing one) →
   resolve it in the extension grammar with the most specific
   `prec`/`prec.dynamic` or `conflicts: [...]` entry that works; don't restate

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -1,0 +1,284 @@
+---
+name: fix-semgrep-grammar
+description: >-
+  Fix the Semgrep extension grammar for a language until `test-lang <lang>`
+  passes. Use when the semgrep grammar build/test fails — typically after an
+  upstream tree-sitter grammar was bumped: parser-generation errors, corpus
+  mismatches, failed example files, or Blank-node warnings under
+  `lang/semgrep-grammars/src/semgrep-<lang>/`. This is "step 4" of the
+  grammar-update process. Edits only this repo's semgrep grammar/tests; never
+  the upstream submodule or the CST→AST translation.
+---
+
+# Fix the Semgrep grammar (step 4)
+
+This repo extends each upstream `tree-sitter-<lang>` grammar with the Semgrep
+pattern constructs below, in `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`,
+via `($, previous) => ...` rule overrides. When upstream changes, the extension
+stops matching and `test-lang` fails. **Make `test-lang <lang>` pass with the
+smallest correct change to the extension grammar and its tests.**
+
+The semgrep constructs to recognize and preserve (rule names vary per language —
+this is the full family seen across the wrappers):
+
+- **Ellipsis** `...` — `ellipsis` / `semgrep_ellipsis`; spliced in as a statement,
+  expression, parameter/argument, and list element (e.g. `catch_ellipsis`,
+  `semgrep_ellipsis_and_comma`, `semgrep_ellipsis_followed_by_newline`).
+- **Named ellipsis** — `semgrep_named_ellipsis`.
+- **Deep ellipsis** `<... e ...>` — `deep_ellipsis` / `semgrep_deep_ellipsis` /
+  `semgrep_deep_expression`.
+- **Metavariables** `$X` — `_semgrep_metavariable` / `semgrep_metavariable`,
+  usually folded into the base `identifier` rule.
+- **Typed metavariables** `(T $X)` — `typed_metavariable` / `semgrep_typed_metavar`
+  (+ `typed_metavariable_declaration`).
+- **Variadic / ellipsis metavariables** `$...X` — `semgrep_variadic_metavariable` /
+  `semgrep_ellipsis_metavariable` / `_semgrep_metavar_ellipsis`.
+- **Member-/field-access ellipsis** `x. ...` — `member_access_ellipsis_expression`
+  / `member_ellipsis_expression` / `field_access_ellipsis_expr`.
+- **Metavariable assignment** `$X = ...`, `$X += ...` — `semgrep_metavar_eq` /
+  `semgrep_metavar_pluseq` (+ `semgrep_val_or_var_definition`).
+- **Alternate entry points** letting a pattern be a bare fragment —
+  `semgrep_expression` / `semgrep_statement` / `semgrep_pattern` /
+  `semgrep_partial`, added to the grammar's start rule (sometimes guarded by a
+  `__SEMGREP_*` token).
+
+## Inputs
+
+- **`<lang>`** — the `test-lang` argument (e.g. `javascript`, `solidity`). Some
+  languages build a different sublanguage set under `lang/`: `typescript`→
+  `typescript tsx`, `php`→`php php-only`, `sfapex`→`apex` (**not** `sfapex`),
+  `cfml`→`cfml`. `test-lang` computes this; steps 1 and 4 act on whichever
+  directories it actually builds, not necessarily `lang/<lang>` itself.
+- **Repo root** — `git rev-parse --show-toplevel`; accept a caller override. Never
+  hardcode an absolute path.
+- **(optional) `max-iterations`** — caps the fix/re-run loop (step 8). Default
+  **8** if not given. Enforced by the skill itself — unlike the Budget hint
+  below, reaching it is a normal, logical stop (see Exit contract).
+- **(optional) Budget hint** — advisory only. Bias toward landing a minimal fix and
+  stopping. You cannot enforce time/turn/cost limits; the harness owns those.
+
+## The loop
+
+1. **Check for uncommitted changes** (precondition, from the repo root):
+   ```
+   git status --porcelain -- lang/semgrep-grammars/src/semgrep-<lang> lang/<sublang-1> lang/<sublang-2> ...
+   ```
+   using the sublanguage set from Inputs (usually just `<lang>` itself — see
+   the exceptions there, e.g. `sfapex` needs `lang/apex`, not `lang/sfapex`).
+   `test-lang` runs `make clean` in every one of these directories on
+   **every** iteration of this loop (step 4), and `make clean` there is `git
+   clean -dfX` — it force-deletes every git-ignored file under that tree, no
+   confirmation, no matter what's actually in it. In this repo that's
+   normally just regenerable build output (`src/`, `test.log`, `CST.ml`,
+   `ocaml-src`, …), but the skill has no way to verify that's still true for
+   an arbitrary `<lang>`, or whether the user left something there they care
+   about. If `git status --porcelain` reports anything under any of these
+   paths (tracked changes *or* untracked-but-ignored files), **stop and tell
+   the user exactly what `git clean -dfX` would remove, and ask them to
+   confirm before proceeding.** Don't assume it's disposable. A clean tree
+   needs no confirmation.
+
+2. **Require the toolchain** (precondition, from the repo root). The tree-sitter
+   version for `<lang>` is pinned in `lang/languages-*`. Verify it is installed; if
+   not, stop with `CANNOT_PROCEED` — provisioning it is the harness's job, not this
+   skill's (installing mutates shared `core/` state):
+   ```
+   v=$(lang/scripts/ts-version-for-lang <lang>)
+   [ -x core/tree-sitter-$v/bin/tree-sitter ] || \
+     { echo "tree-sitter $v is not installed for <lang> — cannot proceed"; exit 1; }
+   ```
+   Report the missing version and the install command the harness should run:
+   `cd core && ./scripts/switch-tree-sitter-version <v> && ./scripts/install-tree-sitter-cli && ./scripts/install-tree-sitter-lib`.
+
+3. **Statically pre-diagnose generate-time breakage, once, before the first
+   run** (from the repo root). `tree-sitter generate` reports only the first
+   broken reference per invocation — it cannot reveal a second broken
+   override until the first is fixed and regenerated, which otherwise forces
+   one full iteration of this loop per rename just to discover the next one.
+   Front-load whatever's discoverable by name before that happens:
+   ```
+   grep -oE '\$\.\w+' lang/semgrep-grammars/src/semgrep-<lang>/grammar.js | sort -u
+   ```
+   For each `$.<name>` this finds, check it's still declared in the *current*
+   upstream grammar (adjust for quoted keys / declaration style):
+   ```
+   grep -n "<name>" lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js
+   ```
+   Any override referencing a name that no longer resolves is a candidate
+   rename/promotion — diagnose it the same way as step 6 (match against
+   upstream's *current* definition, check its recent history), just
+   proactively instead of reactively.
+
+   **A rename found this way needs two edits, not one.** Renaming `<old>` to
+   `<new>` in `grammar.js` fixes `generate`, but any semgrep-owned corpus case
+   whose expected S-expression names `<old>` (e.g. `(<old> ...)`) will then
+   fail `tree-sitter test` on the very next run — that text doesn't update
+   itself. Before running `test-lang` for the first time, also:
+   ```
+   grep -rn "(<old>" lang/semgrep-grammars/src/semgrep-<lang>/test/corpus/*.txt
+   ```
+   (never `test/corpus/inherited` — that's upstream's own corpus and already
+   matches upstream's rename) and batch-substitute `<old>`→`<new>` in every
+   hit. Treat this as a **draft**, not a confirmed fix: a rename upstream
+   isn't guaranteed to be *pure* — the shape or fields around it can change
+   too — so these substitutions still need verifying against the actual
+   output tree once `test-lang` runs, same as any other corpus update (see
+   "Corpus tree drifted" in the Fix playbook). Batch every `grammar.js` and
+   corpus fix this pass finds into a single edit before running `test-lang`
+   for the first time.
+
+   This is a heuristic first pass, not a substitute for step 6 or 5: it only
+   catches breakage that shows up as "this exact name no longer exists," and
+   its corpus substitutions are provisional until verified. It won't catch
+   new conflicts, corpus drift from a non-rename cause, or a symbol that
+   still resolves but now means something different — those still only
+   surface once you actually run `test-lang`, in step 4.
+
+4. **Run** (from the `lang/` dir, not the repo root):
+   ```
+   cd lang && ./test-lang <lang>
+   ```
+   It runs, in order: (a) build + `tree-sitter test` corpus tests in
+   `semgrep-grammars/src/semgrep-<lang>/`, then (b) `parse-examples` for each
+   sublang — the generated parser run over real files in
+   `lang/<sublang>/test/{ok,xfail}` — then (c) a Blank-node check per sublang
+   (see below). `semgrep-grammars/src/semgrep-<lang>/` and every sublang
+   directory are each `make clean`'d (`git clean -dfX` — see step 1) before
+   being rebuilt. Success = **exit code 0** (no unexpected results) **and no
+   new Blank-node warnings** (see baseline, below).
+
+   **Blank-node baseline:** `test-lang`'s Blank-node check (per sublang, grep
+   for `Blank` in `ocaml-src/lib/CST.ml`) is advisory — it never affects
+   `test-lang`'s own exit code. The **first time you run step 4, before any
+   edit from step 7**, record whatever Blank-node warnings it prints as the
+   **baseline**: pre-existing Blank nodes are not this run's problem to fix,
+   and fixing one anyway would violate "smallest correct edit." If that first
+   run fails before reaching the Blank-node check (e.g. a `tree-sitter
+   generate` or corpus error upstream of it), treat the baseline as
+   unknown/empty for that sublang and say so in the exit summary — don't
+   assume it's clean. On every later run, compare the warnings against the
+   baseline: only *new* ones (not present at baseline) count against
+   `SUCCESS`.
+
+5. **Classify** the first failure:
+
+   | Symptom | Meaning |
+   |---|---|
+   | `tree-sitter generate` errors | grammar.js references a rule upstream renamed/removed, or overrides create an unresolved conflict (error names the rule) |
+   | corpus test diff (expected vs actual S-expr) | a `test/corpus/*.txt` expected tree no longer matches a legitimate upstream change |
+   | example in `test.out/fail.list` (CST dumped to `test.out/**/<file>.cst`, look for `!ERROR!`/`ERROR`) | a real source file no longer parses |
+   | Blank-node warning **not in the step-4 baseline** | a node your edit introduced or exposed produces no tokens — give it a named rule |
+
+   A Blank-node warning that *was already in the baseline* is pre-existing and
+   out of scope for this run — leave it alone.
+
+6. **Diagnose against upstream** — match each rule you override to its *current*
+   upstream definition; don't guess. Read
+   `lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js` for the named rule and
+   check what changed: `git -C lang/semgrep-grammars/src/tree-sitter-<lang> log --oneline -5`.
+   For example failures, the `.cst` dump shows exactly which node became `ERROR`.
+
+7. **Apply the smallest correct edit** (playbook below). Change one thing at a
+   time. If the edit adds or changes a rule override, add or extend its corpus
+   case in the same step — see the coverage invariant under Edit boundaries.
+
+8. **Re-run** step 4. Repeat until exit 0, or until `max-iterations` attempts
+   (default **8**) are spent — whichever comes first. Hitting the cap is a
+   normal, logical stop, not a failure to paper over: go to Exit.
+
+9. **Exit** per the contract below.
+
+## Edit boundaries
+
+**May edit (only these):**
+- `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`
+- semgrep-owned corpus files `lang/semgrep-grammars/src/semgrep-<lang>/test/corpus/*.txt` — **never** the `inherited` symlink (it points at the upstream corpus).
+
+**Coverage invariant: every rule override in `grammar.js` — every key in the
+`rules: {}` object — must be exercised by at least one case in the
+semgrep-owned corpus.** `test-lang`'s `parse-examples` step only asserts that
+a file parses without an `ERROR`/`MISSING` node (an exit-code check on the
+whole file); it does not assert *what* tree comes out. A corpus case is the
+only thing in this toolchain that pins the exact expected S-expression, so
+it's the only thing that catches "still parses, but the shape changed"
+regressions. When you add or change a rule override, add or extend its corpus
+case in the same edit — don't defer it, and don't rely on an incidental
+`test/ok` example file being enough (it wasn't written to protect this rule
+and can be moved/pruned without anyone noticing the coverage went with it).
+
+**Never edit:** `tree-sitter-<lang>/` (the submodule, including `scanner.c`); the
+`lang/languages-*` / `language-variants-*` version lists or the submodule pointer;
+anything in the CST→AST / OCaml codegen or the `semgrep` proprietary repo; the
+`inherited` corpus symlink.
+
+**Never weaken semgrep semantics or tests to go green.** Specifically: never
+delete, skip, or relocate a test (e.g. moving an example to `test/xfail/`) to make
+the run pass artificially; never delete a semgrep construct; never rewrite an
+expected corpus tree just to silence a failure. Expected trees change only to
+reflect a *legitimate* upstream structural change. A case you cannot make pass with
+a legitimate grammar change is `CANNOT_PROCEED` (see Exit) — not a test you remove.
+
+## Fix playbook
+
+Common shapes when an upstream bump breaks the extension:
+
+- **Rule renamed upstream** → update every reference (often a `_` added/dropped:
+  `_statement`↔`statement`; or a typo fix: `event_paramater`→`event_parameter`).
+- **Rule promoted to a top-level upstream declaration** → your override now
+  double-defines it (generate conflict); drop the redundant entry.
+- **You copy-pasted a base rule to splice in ellipsis, and upstream refactored it**
+  → stop copying; extend the new upstream rule with `($, previous) =>`. Delete
+  orphaned copied helpers.
+- **Corpus tree drifted** from a legitimate upstream change → update the expected
+  S-expr in `test/corpus/*.txt` to match; verify against the actual tree, don't
+  blindly paste.
+- **Stale `// TODO: use PREC.X`** for a constant that isn't exported → if you must
+  hardcode a precedence, replace the TODO with the one-line reason.
+
+Prefer extending over replacing, and replacing over copy-pasting — the less of the
+upstream rule you restate, the less drifts next time.
+
+## Exit contract
+
+A **logical** stop, or the `max-iterations` cap (step 8) being reached — never a
+resource cap invented on the fly. Print one unmistakable line:
+
+- **`FIX-SEMGREP-GRAMMAR: SUCCESS`** — `test-lang <lang>` exits 0, every rule
+  override in `grammar.js` has a corpus case (the coverage invariant under
+  Edit boundaries), **and** no new Blank-node warnings vs. the step-4 baseline.
+  Summarize the edits (files, fix class, why), which corpus case covers which
+  rule, and the Blank-node baseline you captured, for the PR reviewer.
+- **`FIX-SEMGREP-GRAMMAR: CANNOT_PROCEED`** — no progress for a logical reason: the
+  real fix needs an out-of-scope change (submodule/scanner, translation, version
+  bump), the failure isn't a grammar issue, or fixing it would weaken semgrep
+  semantics. State the blocker, what you tried, and the smallest change that *would*
+  fix it if the boundary were lifted.
+- **`FIX-SEMGREP-GRAMMAR: ITERATION_LIMIT`** — `max-iterations` attempts were spent
+  without reaching exit 0. Summarize every edit tried, the current failure, and your
+  best guess at the next edit, so a human or a fresh run can pick it up.
+
+Do **not** commit, push, or open a PR unless asked. Leave the working tree changed
+for the surrounding grammar-update process's later PR-review stage (a separate,
+outer pipeline from this skill's own numbered steps 1-9 above — the numbering
+isn't shared) to carry into a PR for human review — no auto-merge.
+
+## Running by hand
+
+From the repo, give the agent the language and this skill, e.g.
+`Use fix-semgrep-grammar to make test-lang javascript pass.` Add a tighter cap if you
+want one, e.g. `... pass, with max-iterations 5.` Under the Claude Agent SDK (e.g. a
+Python GitHub Action), invoke with this skill available and enforce the hard limits
+(`max_turns`, budget, an outer `timeout`) at the harness level — `max-iterations`
+bounds the fix loop itself, not turns/tokens/wall-clock, so keep the harness-level
+limits too.
+
+**Toolchain:** `test-lang` needs the per-language tree-sitter version built. This is
+a **precondition the harness provisions** (via the `core/scripts` installers); the
+skill only verifies it (step 2) and reports `CANNOT_PROCEED` if it's missing — it
+never installs it, and never works around a missing toolchain by editing grammar.js.
+
+**Uncommitted state:** step 1 will stop and ask before letting `test-lang` run
+`git clean -dfX` over any dirty `semgrep-<lang>` or sublang tree it's about to
+rebuild. If running unattended (no one to answer the confirmation), the
+harness should either start from a clean checkout or pre-approve/skip step 1
+explicitly — don't silently auto-confirm on the skill's behalf.

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -32,7 +32,8 @@ extension grammar and its tests.**
 - **Repo root** — `git rev-parse --show-toplevel`. Never hardcode an absolute path.
 - **(optional) `max-iterations`** — caps the loop; default **20**. One
   iteration = one step-8 fix plus its step-5 re-run (the step-3 baseline run
-  doesn't count; the step-4 rename batch counts as one). The default is a
+  doesn't count; the step-4 rename batch counts as one; step-8 inner-loop
+  refinements are part of their fix). The default is a
   guess, not empirical; the cap exists to stop runaway loops, not to be
   approached. Reaching it is a normal, logical stop (see Exit contract).
 - **(optional) Budget hint** — advisory only; bias toward landing a minimal fix
@@ -138,14 +139,19 @@ extension grammar and its tests.**
    time — the sole exception is the step-4 rename queue, which lands as one
    batched fix. A fix includes its corpus updates: a rename carries its corpus
    substitutions (step 4), and a new/changed rule override carries its corpus
-   case (coverage invariant, Edit boundaries). When a fix needs a corpus
-   expectation, don't guess the tree and let the loop correct you: a
-   `test-lang` cycle cleans and rebuilds everything (parser, OCaml codegen and
-   compile, every example file — minutes), while `make` in `semgrep-<lang>/`
-   regenerates just the parser (seconds). Get the actual tree with
-   `core/tree-sitter-<v>/bin/tree-sitter parse <snippet>`, check the case with
-   `tree-sitter test --include '<case name>'`, then let the loop's `test-lang`
-   confirm end to end.
+   case (coverage invariant, Edit boundaries).
+
+   **Refine the fix in a fast inner loop before the outer run.** A `test-lang`
+   cycle cleans and rebuilds everything (parser, OCaml codegen and compile,
+   every example file — minutes); `make` in `semgrep-<lang>/` regenerates just
+   the parser (seconds). Iterate there until the fix is locally green:
+   `make` catches generate errors, `core/tree-sitter-<v>/bin/tree-sitter test`
+   runs the corpus, and `... tree-sitter parse <file>` prints the actual tree
+   — both for writing corpus expectations and for checking a failing example
+   file directly. If a few inner attempts haven't gone green, stop tweaking
+   and return to step 7: that's misdiagnosis, not bad luck. The inner loop
+   never replaces the outer run — only `test-lang` (step 9) validates the
+   OCaml build, the example sweep, and the Blank check.
 
 9. **Re-run** step 5. Repeat until exit 0, or until `max-iterations` is spent —
    whichever comes first. Hitting the cap is a normal stop: go to Exit.

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -38,7 +38,7 @@ extension grammar and its tests.**
 - **(optional) Budget hint** — advisory only; bias toward landing a minimal fix
   and stopping. The harness owns hard time/turn/cost limits.
 
-## The loop
+## Preconditions
 
 1. **Check for uncommitted changes** (precondition, from the repo root):
    ```
@@ -111,6 +111,8 @@ extension grammar and its tests.**
    catches "this name no longer exists"; conflicts, corpus drift, and symbols
    that still resolve but changed meaning surface only when `test-lang` runs.
 
+## The loop
+
 5. **Run** `cd lang && ./test-lang <lang>` again (if step 4 changed nothing,
    reuse the step-3 output instead of re-running). Success = **exit code 0
    and no new Blank-node warnings vs. the step-3 baseline**.
@@ -136,11 +138,14 @@ extension grammar and its tests.**
    time — the sole exception is the step-4 rename queue, which lands as one
    batched fix. A fix includes its corpus updates: a rename carries its corpus
    substitutions (step 4), and a new/changed rule override carries its corpus
-   case (coverage invariant, Edit boundaries). To derive and verify a corpus
-   expectation without burning an iteration: `make` in `semgrep-<lang>/`, then
-   `core/tree-sitter-<v>/bin/tree-sitter parse <snippet>` for the actual tree
-   and `tree-sitter test --include '<case name>'` for the case — then re-run
-   `test-lang` to confirm end to end.
+   case (coverage invariant, Edit boundaries). When a fix needs a corpus
+   expectation, don't guess the tree and let the loop correct you: a
+   `test-lang` cycle cleans and rebuilds everything (parser, OCaml codegen and
+   compile, every example file — minutes), while `make` in `semgrep-<lang>/`
+   regenerates just the parser (seconds). Get the actual tree with
+   `core/tree-sitter-<v>/bin/tree-sitter parse <snippet>`, check the case with
+   `tree-sitter test --include '<case name>'`, then let the loop's `test-lang`
+   confirm end to end.
 
 9. **Re-run** step 5. Repeat until exit 0, or until `max-iterations` is spent —
    whichever comes first. Hitting the cap is a normal stop: go to Exit.

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -234,6 +234,27 @@ Common shapes when an upstream bump breaks the extension:
   blindly paste.
 - **Stale `// TODO: use PREC.X`** for a constant that isn't exported → if you must
   hardcode a precedence, replace the TODO with the one-line reason.
+- **New parse conflict** (generate error names two rules, not a missing one) →
+  resolve it in the extension grammar with the most specific `prec`/`prec.dynamic`
+  or `conflicts: [...]` entry that works; don't restate upstream rules to dodge it.
+- **Failure traces to an external token** — one listed in upstream's `externals:`
+  array and produced by `scanner.c` → the real fix lives in the scanner, which is
+  out of scope: `CANNOT_PROCEED`, naming the token.
+- **Upstream changed the `word:`/identifier token** → metavariables folded into
+  `identifier` may stop lexing; re-fold them against the new identifier rule. If
+  `$X` can no longer be admitted without scanner changes, `CANNOT_PROCEED`.
+- **New upstream syntax collides with a semgrep construct** (e.g. upstream adds
+  real `...` or `$`-prefixed names) → try precedence/token ordering so both
+  survive; if the construct can't be disambiguated without weakening it,
+  `CANNOT_PROCEED`.
+- **Upstream restructured its grammar file layout** (e.g. a dialect factory like
+  `common/define-grammar.js`) → update the extension's `require(...)`/wrapping to
+  the new entry point; the rule overrides themselves may need no change.
+- **Upstream deliberately dropped syntax**, so a `test/ok` example or corpus case
+  is legitimately no longer parseable → do **not** move it to `xfail`, delete it,
+  or rewrite it on your own: **warn the user, state exactly what upstream dropped
+  and which tests it strands, and ask how to proceed.** If no one can answer
+  (unattended run), exit `CANNOT_PROCEED` with that question as the blocker.
 
 Prefer extending over replacing, and replacing over copy-pasting — the less of the
 upstream rule you restate, the less drifts next time.

--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -5,12 +5,12 @@ description: >-
   passes. Use when the semgrep grammar build/test fails — typically after an
   upstream tree-sitter grammar was bumped: parser-generation errors, corpus
   mismatches, failed example files, or Blank-node warnings under
-  `lang/semgrep-grammars/src/semgrep-<lang>/`. This is "step 4" of the
-  grammar-update process. Edits only this repo's semgrep grammar/tests; never
+  `lang/semgrep-grammars/src/semgrep-<lang>/`.
+  Edits only this repo's semgrep grammar/tests; never
   the upstream submodule or the CST→AST translation.
 ---
 
-# Fix the Semgrep grammar (step 4)
+# Fix the Semgrep grammar
 
 This repo extends each upstream `tree-sitter-<lang>` grammar with semgrep
 pattern constructs — ellipsis `...`, metavariables `$X`, deep ellipsis
@@ -31,11 +31,10 @@ extension grammar and its tests.**
   lang itself). Steps 1 and 4 act on whichever directories it builds.
 - **Repo root** — `git rev-parse --show-toplevel`. Never hardcode an absolute path.
 - **(optional) `max-iterations`** — caps the loop; default **20**. One
-  iteration = one step-7 fix plus its step-4 re-run (the initial baseline run
-  doesn't count; the step-3 rename batch counts as one). The default is a
-  guess, not empirical — the worst run measured so far (Solidity) needed ~6
-  fixes; the cap exists to stop runaway loops, not to be approached. Reaching
-  it is a normal, logical stop (see Exit contract).
+  iteration = one step-8 fix plus its step-5 re-run (the step-3 baseline run
+  doesn't count; the step-4 rename batch counts as one). The default is a
+  guess, not empirical; the cap exists to stop runaway loops, not to be
+  approached. Reaching it is a normal, logical stop (see Exit contract).
 - **(optional) Budget hint** — advisory only; bias toward landing a minimal fix
   and stopping. The harness owns hard time/turn/cost limits.
 
@@ -45,34 +44,49 @@ extension grammar and its tests.**
    ```
    git status --porcelain --ignored -- lang/semgrep-grammars/src/semgrep-<lang> lang/<sublang-1> lang/<sublang-2> ...
    ```
-   using the sublanguage set from Inputs (`--ignored` matters — plain status
-   won't list the ignored files `git clean -dfX` deletes). `test-lang` runs
-   `make clean` in each of these directories on every iteration, and `make
-   clean` there is `git clean -dfX`: it force-deletes every git-ignored file
-   under the tree, no confirmation. Normally that's regenerable build output
-   (`src/`, `test.log`, `CST.ml`, `ocaml-src`, …), but don't assume. If the
-   status reports anything — tracked changes *or* untracked/ignored files —
-   **stop, list exactly what `git clean -dfX` would remove (noting which files
-   are recognizably generated: generated-file headers, standard artifact
-   names), and ask the user to confirm.** A clean tree needs no confirmation.
+   using the sublanguage set from Inputs (`--ignored` matters: plain status
+   misses ignored files). Every `test-lang` iteration runs `git clean -dfX`
+   in each of these directories — force-deleting all git-ignored files, no
+   confirmation. That's normally regenerable build output, but don't assume:
+   if the status reports anything, **stop, list what would be deleted (noting
+   which files look machine-generated), and ask the user to confirm.** A
+   clean tree needs no confirmation.
 
-2. **Require the toolchain** (precondition, from the repo root). The
-   tree-sitter version for `<lang>` is pinned in `lang/languages-*`; verify it,
-   never install it (installing mutates shared `core/` state — that's the
-   harness's job):
+2. **Ensure the toolchain** (from the repo root). Grammar builds are
+   parametrized on the `lang/languages-*` pins; each pinned version lives
+   side by side in `core/tree-sitter-<version>/`:
    ```
    v=$(lang/scripts/ts-version-for-lang <lang>)
-   [ -x core/tree-sitter-$v/bin/tree-sitter ] || \
-     { echo "tree-sitter $v is not installed for <lang> — cannot proceed"; exit 1; }
+   [ -x core/tree-sitter-$v/bin/tree-sitter ] || make setup-tree-sitter-versions
    ```
-   If missing, stop with `CANNOT_PROCEED`, reporting the version and the
-   install command for the harness to run: `cd core &&
-   ./scripts/switch-tree-sitter-version <v> && ./scripts/install-tree-sitter-cli
-   && ./scripts/install-tree-sitter-lib`.
+   `make setup-tree-sitter-versions` installs every pinned version and then
+   restores the repo's default `core/tree-sitter-version`. Never run
+   `core/scripts/switch-tree-sitter-version` on its own — it changes that
+   default. If the install fails, stop with `CANNOT_PROCEED` reporting the
+   error.
 
-3. **Statically pre-diagnose broken references, once, before the first run.**
-   `tree-sitter generate` reports only the first broken reference per
-   invocation, so find them all by name up front:
+3. **Capture the Blank-node baseline** — run `test-lang` once, before any
+   edit (from the `lang/` dir, not the repo root):
+   ```
+   cd lang && ./test-lang <lang>
+   ```
+   It runs, in order: (a) build + `tree-sitter test` corpus tests in
+   `semgrep-grammars/src/semgrep-<lang>/`, (b) `parse-examples` per sublang —
+   the generated parser over real files in `lang/<sublang>/test/{ok,xfail}` —
+   (c) a Blank-node check per sublang, grepping generated
+   `ocaml-src/lib/CST.ml` (advisory: it never affects the exit code). Each
+   directory is `git clean -dfX`'d first (step 1).
+
+   If this run reaches the check for a sublang, its warnings are that
+   sublang's **baseline** — pre-existing Blank nodes are out of scope, and
+   fixing one would violate "smallest correct edit". If it fails earlier, the
+   baseline is **empty** and `SUCCESS` requires no Blank-node warnings at
+   all. Keep the run's failure output — it feeds step 6. This run doesn't
+   count toward `max-iterations`.
+
+4. **Statically pre-diagnose broken references, once.** `tree-sitter
+   generate` reports only the first broken reference per invocation, so find
+   them all by name up front:
    ```
    grep -oE '\$\.\w+' lang/semgrep-grammars/src/semgrep-<lang>/grammar.js | sort -u
    ```
@@ -81,10 +95,10 @@ extension grammar and its tests.**
    each remaining name still resolves in the *current*
    `lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js` (adjust for quoted
    keys / declaration style). Each name that doesn't is a candidate
-   rename/promotion — diagnose it per step 6, proactively. Apply the verified
+   rename/promotion — diagnose it per step 7, proactively. Apply the verified
    rename queue as a **single batched fix** — renames are one fix class and
    `generate` validates them together; everything else stays one fix per
-   iteration (step 7).
+   iteration (step 8).
 
    A rename fix has two parts, applied together as one edit: the `grammar.js`
    reference *and* every semgrep-owned corpus case naming the old node:
@@ -95,60 +109,43 @@ extension grammar and its tests.**
    substitutions are drafts until verified against actual output once
    `test-lang` runs — an upstream rename isn't guaranteed pure. This pass only
    catches "this name no longer exists"; conflicts, corpus drift, and symbols
-   that still resolve but changed meaning surface only in step 4.
+   that still resolve but changed meaning surface only when `test-lang` runs.
 
-4. **Run** (from the `lang/` dir, not the repo root):
-   ```
-   cd lang && ./test-lang <lang>
-   ```
-   In order: (a) build + `tree-sitter test` corpus tests in
-   `semgrep-grammars/src/semgrep-<lang>/`, (b) `parse-examples` per sublang —
-   the generated parser over real files in `lang/<sublang>/test/{ok,xfail}` —
-   (c) a Blank-node check per sublang. Each directory is `git clean -dfX`'d
-   first (step 1). Success = **exit code 0 and no new Blank-node warnings vs.
-   the baseline**.
+5. **Run** `cd lang && ./test-lang <lang>` again (if step 4 changed nothing,
+   reuse the step-3 output instead of re-running). Success = **exit code 0
+   and no new Blank-node warnings vs. the step-3 baseline**.
 
-   **Blank-node baseline:** the check greps generated `ocaml-src/lib/CST.ml`,
-   so it can only report on a run that builds far enough to produce that file;
-   it is advisory and never affects `test-lang`'s exit code. If the **first**
-   run (before any edit) reaches the check for a sublang, its warnings are
-   that sublang's baseline — those pre-existing Blank nodes are out of scope,
-   and fixing one would violate "smallest correct edit". If the first run
-   fails before the check, the baseline is **empty**: `SUCCESS` then requires
-   no Blank-node warnings at all. On later runs, only warnings not in the
-   baseline count against `SUCCESS`.
-
-5. **Classify** the first failure:
+6. **Classify** the first failure:
 
    | Symptom | Meaning |
    |---|---|
    | `tree-sitter generate` errors | grammar.js references a rule upstream renamed/removed, or the overrides create an unresolved conflict (the error names the rule) |
-   | corpus test diff (expected vs actual S-expr) | expected tree ≠ actual — either a legitimate upstream change or a regression from your own earlier edit; step 6 decides which |
+   | corpus test diff (expected vs actual S-expr) | expected tree ≠ actual — either a legitimate upstream change or a regression from your own earlier edit; step 7 decides which |
    | example in `test.out/fail.list` — entries are paths relative to `lang/<sublang>/test/ok/`; each CST dump is at `test.out/ok/<entry>.cst` (look for `!ERROR!`/`ERROR`) | a real source file no longer parses |
    | Blank-node warning not in the baseline | a node your edit introduced or exposed produces no tokens — give it a named rule |
    | tree-sitter version/ABI errors (grammar needs a newer tree-sitter than the pin, ABI mismatch) | the `lang/languages-*` pin is stale, not a grammar bug — out of scope: `CANNOT_PROCEED`, reporting the version-list change needed |
 
-6. **Diagnose against upstream** — match each rule you override to its
+7. **Diagnose against upstream** — match each rule you override to its
    *current* definition in `lang/semgrep-grammars/src/tree-sitter-<lang>/grammar.js`
    and check what changed:
    `git -C lang/semgrep-grammars/src/tree-sitter-<lang> log --oneline -5`.
    For example failures, the `.cst` dump shows which node became `ERROR`.
    Don't guess.
 
-7. **Apply the smallest correct edit** (playbook below), one logical fix at a
-   time — the sole exception is the step-3 rename queue, which lands as one
+8. **Apply the smallest correct edit** (playbook below), one logical fix at a
+   time — the sole exception is the step-4 rename queue, which lands as one
    batched fix. A fix includes its corpus updates: a rename carries its corpus
-   substitutions (step 3), and a new/changed rule override carries its corpus
+   substitutions (step 4), and a new/changed rule override carries its corpus
    case (coverage invariant, Edit boundaries). To derive and verify a corpus
    expectation without burning an iteration: `make` in `semgrep-<lang>/`, then
    `core/tree-sitter-<v>/bin/tree-sitter parse <snippet>` for the actual tree
    and `tree-sitter test --include '<case name>'` for the case — then re-run
    `test-lang` to confirm end to end.
 
-8. **Re-run** step 4. Repeat until exit 0, or until `max-iterations` is spent —
+9. **Re-run** step 5. Repeat until exit 0, or until `max-iterations` is spent —
    whichever comes first. Hitting the cap is a normal stop: go to Exit.
 
-9. **Exit** per the contract below.
+10. **Exit** per the contract below.
 
 ## Edit boundaries
 
@@ -263,7 +260,4 @@ From the repo, give the agent the language and this skill, e.g.
 a tighter cap, e.g. `... pass, with max-iterations 5.` Under the Claude Agent
 SDK (e.g. a Python GitHub Action), keep the hard limits (`max_turns`, budget,
 an outer `timeout`) at the harness level — `max-iterations` bounds only the fix
-loop. The tree-sitter toolchain is a precondition the harness provisions (step
-2 only verifies it). Unattended runs should start from a clean checkout or
-explicitly pre-approve step 1's confirmation — never silently auto-confirm on
-the skill's behalf.
+loop.

--- a/.agents/skills/fix-semgrep-grammar/references/semgrep-constructs.md
+++ b/.agents/skills/fix-semgrep-grammar/references/semgrep-constructs.md
@@ -1,7 +1,11 @@
 # Semgrep construct name inventory
 
 The semgrep pattern constructs the extension grammars add. Rule names vary per
-language — this is the full family seen across the wrappers:
+language — this is the full family seen across the wrappers. (No other
+inventory exists: the repo's `doc/README.md` links out to
+https://docs.semgrep.dev/contributing/adding-a-language, which names only `$X`
+and `...`; the user-facing construct list is
+https://docs.semgrep.dev/writing-rules/pattern-syntax.)
 
 - **Ellipsis** `...` — `ellipsis` / `semgrep_ellipsis`; spliced in as a statement,
   expression, parameter/argument, and list element (e.g. `catch_ellipsis`,
@@ -10,7 +14,12 @@ language — this is the full family seen across the wrappers:
 - **Deep ellipsis** `<... e ...>` — `deep_ellipsis` / `semgrep_deep_ellipsis` /
   `semgrep_deep_expression`.
 - **Metavariables** `$X` — `_semgrep_metavariable` / `semgrep_metavariable`,
-  usually folded into the base `identifier` rule.
+  usually folded into the base `identifier` rule. Anonymous metavariables
+  (`$_`) need no separate rule — they lex as ordinary metavariables.
+- **Literal metavariables** — `$X` inside string (`"$X"`), regex (`/$X/`), or
+  atom (`:$X`) literals. Often handled post-parse in the CST→AST layer, but
+  some wrappers admit them in the grammar, e.g. elixir's
+  `metavariable_atom: seq(":", $._semgrep_metavariable)`.
 - **Typed metavariables** `(T $X)` — `typed_metavariable` / `semgrep_typed_metavar`
   (+ `typed_metavariable_declaration`).
 - **Variadic / ellipsis metavariables** `$...X` — `semgrep_variadic_metavariable` /

--- a/.agents/skills/fix-semgrep-grammar/references/semgrep-constructs.md
+++ b/.agents/skills/fix-semgrep-grammar/references/semgrep-constructs.md
@@ -1,0 +1,25 @@
+# Semgrep construct name inventory
+
+The semgrep pattern constructs the extension grammars add. Rule names vary per
+language — this is the full family seen across the wrappers:
+
+- **Ellipsis** `...` — `ellipsis` / `semgrep_ellipsis`; spliced in as a statement,
+  expression, parameter/argument, and list element (e.g. `catch_ellipsis`,
+  `semgrep_ellipsis_and_comma`, `semgrep_ellipsis_followed_by_newline`).
+- **Named ellipsis** — `semgrep_named_ellipsis`.
+- **Deep ellipsis** `<... e ...>` — `deep_ellipsis` / `semgrep_deep_ellipsis` /
+  `semgrep_deep_expression`.
+- **Metavariables** `$X` — `_semgrep_metavariable` / `semgrep_metavariable`,
+  usually folded into the base `identifier` rule.
+- **Typed metavariables** `(T $X)` — `typed_metavariable` / `semgrep_typed_metavar`
+  (+ `typed_metavariable_declaration`).
+- **Variadic / ellipsis metavariables** `$...X` — `semgrep_variadic_metavariable` /
+  `semgrep_ellipsis_metavariable` / `_semgrep_metavar_ellipsis`.
+- **Member-/field-access ellipsis** `x. ...` — `member_access_ellipsis_expression`
+  / `member_ellipsis_expression` / `field_access_ellipsis_expr`.
+- **Metavariable assignment** `$X = ...`, `$X += ...` — `semgrep_metavar_eq` /
+  `semgrep_metavar_pluseq` (+ `semgrep_val_or_var_definition`).
+- **Alternate entry points** letting a pattern be a bare fragment —
+  `semgrep_expression` / `semgrep_statement` / `semgrep_pattern` /
+  `semgrep_partial`, added to the grammar's start rule (sometimes guarded by a
+  `__SEMGREP_*` token).

--- a/.claude/skills
+++ b/.claude/skills
@@ -1,0 +1,1 @@
+../.agents/skills

--- a/doc/README.md
+++ b/doc/README.md
@@ -4,6 +4,7 @@ ocaml-tree-sitter documentation
 * [How to add support for a new language](http://semgrep.dev/docs/contributing/adding-a-language/)
 * [How to upgrade the grammar for a language](http://semgrep.dev/docs/contributing/updating-a-grammar/)
 * [Semgrep pattern-construct inventory for extension grammars](semgrep-constructs.md)
+* [fix-semgrep-grammar: the grammar-repair agent skill](fix-semgrep-grammar-skill.md)
 * [Releasing generated code for semgrep](release.md)
 
 See also:

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,6 +3,7 @@ ocaml-tree-sitter documentation
 
 * [How to add support for a new language](http://semgrep.dev/docs/contributing/adding-a-language/)
 * [How to upgrade the grammar for a language](http://semgrep.dev/docs/contributing/updating-a-grammar/)
+* [Semgrep pattern-construct inventory for extension grammars](semgrep-constructs.md)
 * [Releasing generated code for semgrep](release.md)
 
 See also:

--- a/doc/fix-semgrep-grammar-skill.md
+++ b/doc/fix-semgrep-grammar-skill.md
@@ -1,0 +1,45 @@
+# fix-semgrep-grammar: the grammar-repair agent skill
+
+An agent skill (`.agents/skills/fix-semgrep-grammar/SKILL.md`) that repairs
+the semgrep extension grammar after an upstream tree-sitter bump, iterating
+until `test-lang <lang>` passes.
+
+## Inputs
+
+- `<lang>` — the `test-lang` argument (e.g. `javascript`).
+- *(optional)* `max-iterations` — caps the fix/re-run loop; default 20.
+- *(optional)* a budget hint — advisory; biases toward a minimal fix.
+
+## Where it operates
+
+It edits only `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js` and the
+semgrep-owned corpus files `.../test/corpus/*.txt`. It never touches the
+upstream submodule (including `scanner.c`), the `lang/languages-*` version
+pins, or the CST→AST / OCaml codegen, and it never commits or opens PRs.
+
+## Running it by hand
+
+Give an agent the language and the skill:
+
+    Use fix-semgrep-grammar to make test-lang javascript pass.
+
+Optionally add a tighter cap: `... pass, with max-iterations 5.` The skill
+asks for confirmation before letting `test-lang` run `git clean -dfX` over a
+dirty tree.
+
+## Exit statuses
+
+The skill always ends with one machine-readable line:
+
+- `FIX-SEMGREP-GRAMMAR: SUCCESS` — `test-lang` exits 0, new/changed overrides
+  have corpus coverage, no new Blank nodes.
+- `FIX-SEMGREP-GRAMMAR: CANNOT_PROCEED` — the real fix is outside the skill's
+  edit boundaries (with the blocker stated).
+- `FIX-SEMGREP-GRAMMAR: ITERATION_LIMIT` — the cap was reached; the summary
+  lets a human or a fresh run pick up.
+
+## Limits
+
+The skill is SKILL.md instructions only: it stops for logical reasons but
+cannot enforce turn, cost, or wall-clock limits — run it under harness-level
+caps (`max_turns`, budget, an outer timeout).

--- a/doc/semgrep-constructs.md
+++ b/doc/semgrep-constructs.md
@@ -1,11 +1,11 @@
 # Semgrep construct name inventory
 
-The semgrep pattern constructs the extension grammars add. Rule names vary per
-language — this is the full family seen across the wrappers. (No other
-inventory exists: the repo's `doc/README.md` links out to
-https://docs.semgrep.dev/contributing/adding-a-language, which names only `$X`
-and `...`; the user-facing construct list is
-https://docs.semgrep.dev/writing-rules/pattern-syntax.)
+The semgrep pattern constructs that the extension grammars
+(`lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`) add on top of each
+upstream tree-sitter grammar. Rule names vary per language — this is the full
+family seen across the wrappers, mapping the user-facing pattern syntax
+(https://docs.semgrep.dev/writing-rules/pattern-syntax) to grammar-level rule
+names.
 
 - **Ellipsis** `...` — `ellipsis` / `semgrep_ellipsis`; spliced in as a statement,
   expression, parameter/argument, and list element (e.g. `catch_ellipsis`,

--- a/lang/semgrep-grammars/src/semgrep-javascript/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-javascript/grammar.js
@@ -11,7 +11,12 @@ const javascript_grammar = require('tree-sitter-javascript/grammar');
 
 module.exports = grammar(javascript_grammar, {
   name: 'javascript',
-  rules: {}
+  rules: {
+    // Allow a bare '>' among JSX element children. The upstream external
+    // scanner ends a jsx_text token at '>', but a literal '>' between
+    // tags is valid JSX.
+    _jsx_child: ($, previous) => choice(previous, '>'),
+  }
 });
 
 // copy-pasted from the original grammar

--- a/lang/semgrep-grammars/src/semgrep-javascript/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-javascript/test/corpus/semgrep.txt
@@ -1,0 +1,16 @@
+============================================
+Bare '>' among JSX element children
+============================================
+
+const x = <div>a > b</div>;
+
+---
+
+(program
+  (lexical_declaration (variable_declarator
+    (identifier)
+    (jsx_element
+      (jsx_opening_element (identifier))
+      (jsx_text)
+      (jsx_text)
+      (jsx_closing_element (identifier))))))


### PR DESCRIPTION
### Checklist

- [x] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)

### **Related PRs:**

- https://github.com/semgrep/semgrep-javascript/pull/2
- **NOTE:** no integration in semgrep-proprietary at this stage.

### What

Closes LANG-584: an agent skill that repairs the semgrep extension grammar after an upstream tree-sitter bump, plus the JavaScript fix produced by running it.

- **`.agents/skills/fix-semgrep-grammar/SKILL.md`** — drives an agent through: preconditions, then a bounded fix loop with strict edit boundaries, and machine-readable exit statuses.
- **`doc/semgrep-constructs.md`** — inventory mapping user-facing semgrep pattern syntax to the grammar-level rule names used across the wrappers; linked from the doc index and referenced by the skill.
- **`doc/fix-semgrep-grammar-skill.md`** — short usage doc (inputs, where it operates, how to run it by hand, exit statuses), per LANG-584.
- **`lang/semgrep-grammars/src/semgrep-javascript/`** — We obtain parity with the Menhir parser by making `_jsx_child` to accept a bare `>` among JSX children and add a tree-sitter grammar test.

### Validation

- Ran the skill for java script, then `test-lang javascript` exits 0 with no Blank-node warnings.

The skill was trained on fixes required for JS as well as Solidity. The Solidity fix will be in a separate PR. This also relates to LANG-579 but does NOT close it.