### PR TITLE
feat(ruby): bump tree-sitter-ruby to v0.23.1

### DIFF
--- a/lang/language-variants-0.20.8
+++ b/lang/language-variants-0.20.8
@@ -1,4 +1,3 @@
 apex
 r
-ruby
 solidity

--- a/lang/language-variants-0.22.6
+++ b/lang/language-variants-0.22.6
@@ -26,6 +26,7 @@ ocaml
 promql
 proto
 ql
+ruby
 rust
 scala
 sqlite

--- a/lang/languages-0.20.8
+++ b/lang/languages-0.20.8
@@ -1,5 +1,4 @@
 r
-ruby
 sfapex
 solidity
 soql

--- a/lang/languages-0.22.6
+++ b/lang/languages-0.22.6
@@ -28,6 +28,7 @@ promql
 proto
 ql
 requirements
+ruby
 rust
 scala
 sqlite


### PR DESCRIPTION
## Summary

- Bump `tree-sitter-ruby` submodule to v0.23.1 (`71bd32f`).
- Add `ruby` to the tree-sitter 0.22.6 language membership lists.

**Companion PRs:**

- https://github.com/semgrep/semgrep-ruby/pull/3
- https://github.com/semgrep/semgrep-proprietary/pull/6705

## Test plan

- [x] `test-lang ruby` passes in CI
- [x] Downstream integration in semgrep-proprietary (see report-back comment)