### PR TITLE
Update tree-sitter-solidity grammar to v1.2.13

### DIFF
--- a/lang/language-variants-0.20.8
+++ b/lang/language-variants-0.20.8
@@ -1,4 +1,3 @@
 apex
 r
 ruby
-solidity

--- a/lang/language-variants-0.26.3
+++ b/lang/language-variants-0.26.3
@@ -5,3 +5,4 @@ php
 php-only
 powershell
 python
+solidity

--- a/lang/languages-0.20.8
+++ b/lang/languages-0.20.8
@@ -1,6 +1,5 @@
 r
 ruby
 sfapex
-solidity
 soql
 sosl

--- a/lang/languages-0.26.3
+++ b/lang/languages-0.26.3
@@ -4,3 +4,4 @@ gosu
 php
 powershell
 python
+solidity

--- a/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-solidity/grammar.js
@@ -24,11 +24,10 @@ module.exports = grammar(base_grammar, {
         source_file: ($, previous) => {
           return choice(
             previous,
-            repeat1($._statement),
-            $._expression,
+            repeat1($.statement),
+            $.expression,
             $.constructor_definition,
             $.modifier_definition,
-            $.event_definition,
           );
         },
 
@@ -47,9 +46,9 @@ module.exports = grammar(base_grammar, {
                 ),
             )
         },
-      
+
       // Ellipsis
-        _expression: ($, previous) => {
+        expression: ($, previous) => {
             return choice(
                 previous,
                 $.ellipsis,
@@ -70,7 +69,7 @@ module.exports = grammar(base_grammar, {
        // TODO: how to use PREC.MEMBER from original grammar instead of hardcoded value?
        member_ellipsis_expression : $ => prec(1, seq(
             field('object', choice(
-                $._expression,
+                $.expression,
                 $.identifier,
             )),
             '.',
@@ -98,7 +97,7 @@ module.exports = grammar(base_grammar, {
         },
 
         // typo on name in the original grammar so we must copy the typo
-        event_paramater: ($, previous) => {
+        event_parameter: ($, previous) => {
             return choice(
                previous,
                $.ellipsis
@@ -108,7 +107,7 @@ module.exports = grammar(base_grammar, {
         for_statement: ($, previous) => {
             return choice(
                previous,
-               seq('for', '(', $.ellipsis, ')', $._statement)
+               seq('for', '(', $.ellipsis, ')', $.statement)
             );
         },
 
@@ -119,32 +118,25 @@ module.exports = grammar(base_grammar, {
             );
         },
 
-      //TODO? it would be better to refactor the original grammar with
-      // a enum_member so we don't have to copy-paste the original rule
-      enum_declaration: $ =>  seq(
-            'enum',
-            field("enum_type_name", $.identifier),
+        enum_body: $ => seq(
             '{',
-            commaSep($._enum_member),
+            commaSep(choice(
+                alias($.identifier, $.enum_value),
+                $.ellipsis
+            )),
             '}',
-      ),
-      _enum_member: $ => choice(
-          alias($.identifier, $.enum_value),
-          $.ellipsis
-      ),
+        ),
 
       // The actual ellipsis rules
         deep_ellipsis: $ => seq(
-            '<...', $._expression, '...>'
+            '<...', $.expression, '...>'
         ),
 
         ellipsis: $ => '...',
   }
 });
 
-// copy-pasted from the original grammar, because of our copy-paste of enum_declaration
-// once the original grammar is rewritten with a enum_member, we would not need
-// those defs anymore
+// copy-pasted from the original grammar for enum_body ellipsis support
 function commaSep1(rule) {
     return seq(
         rule,

--- a/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
@@ -43,7 +43,11 @@ for(...) {
 ---
 
 (source_file
-  (for_statement (ellipsis) (block_statement)))
+  (statement
+    (for_statement
+      (ellipsis)
+      (statement
+        (block_statement)))))
 
 =====================================
 Constructor pattern
@@ -57,8 +61,9 @@ constructor (...) {
         (parameter
           (ellipsis))
         (function_body
-          (expression_statement
-            (ellipsis)))))
+          (statement
+            (expression_statement
+              (ellipsis))))))
 
 =====================================
 Modifier pattern
@@ -74,8 +79,9 @@ modifier $M(...) {
         (parameter
           (ellipsis))
         (function_body
-          (expression_statement
-            (ellipsis)))))
+          (statement
+            (expression_statement
+              (ellipsis))))))
 
 =====================================
 Inheritance ellipsis pattern
@@ -107,7 +113,8 @@ enum $X {
 (source_file
       (enum_declaration
         (identifier)
-        (ellipsis)))
+        (enum_body
+          (ellipsis))))
 
 =====================================
 Event pattern
@@ -119,5 +126,5 @@ event $EV(...);
 (source_file
       (event_definition
         (identifier)
-        (event_paramater
+        (event_parameter
           (ellipsis))))


### PR DESCRIPTION
Automated grammar update for **solidity**.

- Upstream: https://github.com/JoranHonig/tree-sitter-solidity.git
- `4e79c49eb4cb68f417411f97a0b9cbd4d5862752` → `4e938a46c7030dd001bc99e1ac0f0c750ac98254` (**v1.2.13**)
- tree-sitter version: `0.26.3`
- Compare: https://github.com/JoranHonig/tree-sitter-solidity/compare/4e79c49eb4cb68f417411f97a0b9cbd4d5862752...v1.2.13

Corpus snapshots were auto-regenerated. **Please review** the parse-tree changes below — especially any `:error` (error-recovery) cases, which `tree-sitter test --update` does not touch automatically.

> ⚠️ **The fix-semgrep-grammar skill patched the extension grammar and/or its tests** for this bump (test-lang failed on the raw bump, typically a mechanical upstream CST rename). Scrutinize those changes in the diff.

<details>
<summary>Corpus snapshot diff</summary>

```diff
diff --git a/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt b/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
index e9e09a2..c1d174a 100644
--- a/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-solidity/test/corpus/semgrep.txt
@@ -43,7 +43,11 @@ for(...) {
 ---
 
 (source_file
-  (for_statement (ellipsis) (block_statement)))
+  (statement
+    (for_statement
+      (ellipsis)
+      (statement
+        (block_statement)))))
 
 =====================================
 Constructor pattern
@@ -57,8 +61,9 @@ constructor (...) {
         (parameter
           (ellipsis))
         (function_body
-          (expression_statement
-            (ellipsis)))))
+          (statement
+            (expression_statement
+              (ellipsis))))))
 
 =====================================
 Modifier pattern
@@ -74,8 +79,9 @@ modifier $M(...) {
         (parameter
           (ellipsis))
         (function_body
-          (expression_statement
-            (ellipsis)))))
+          (statement
+            (expression_statement
+              (ellipsis))))))
 
 =====================================
 Inheritance ellipsis pattern
@@ -107,7 +113,8 @@ enum $X {
 (source_file
       (enum_declaration
         (identifier)
-        (ellipsis)))
+        (enum_body
+          (ellipsis))))
 
 =====================================
 Event pattern
@@ -119,5 +126,5 @@ event $EV(...);
 (source_file
       (event_definition
         (identifier)
-        (event_paramater
+        (event_parameter
           (ellipsis))))
```

</details>

<details>
<summary>test-lang output (tail)</summary>

```
test-lang solidity exits 0 after fix-semgrep-grammar adapted the extension grammar (4/15 iterations).
```

</details>

Companion PRs:

- https://github.com/semgrep/semgrep-proprietary/pull/6563
- https://github.com/semgrep/semgrep-solidity/pull/3
- https://github.com/semgrep/semgrep-rules/pull/3997

Relates to LANG-207 but does NOT close it.