### PR TITLE
Put the pinned tree-sitter CLI on PATH globally, with priority

### DIFF
--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -39,6 +39,7 @@ Modes:
 from __future__ import annotations
 
 import argparse
+import contextlib
 import json
 import os
 import re
@@ -336,6 +337,41 @@ def is_up_to_date(root: Path, language: str) -> bool | None:
 def wrapper_dir(root: Path, wrapper: str) -> Path:
     """Return the semgrep-<wrapper> directory under semgrep-grammars/src."""
     return root / "lang" / "semgrep-grammars" / "src" / f"semgrep-{wrapper}"
+
+
+@contextlib.contextmanager
+def _stdout_to_stderr():
+    """Redirect fd 1 to fd 2 temporarily.
+
+    update-grammar's `run()` inherits stdout for subprocesses it doesn't
+    capture; this script's stdout must stay a single JSON line.
+    """
+    sys.stdout.flush()
+    saved_fd = os.dup(1)
+    try:
+        os.dup2(2, 1)
+        yield
+    finally:
+        sys.stdout.flush()
+        os.dup2(saved_fd, 1)
+        os.close(saved_fd)
+
+
+def ensure_ts_version_on_path(root: Path, ts_version: str) -> None:
+    """Put `ts_version`'s tree-sitter CLI on PATH, ahead of everything else.
+
+    test-lang, release, and update-grammar's own re-run all shell out to a
+    bare `tree-sitter`; CI sets this up via GITHUB_PATH, a local run
+    doesn't. Reuses update-grammar's self-healing `ensure_tree_sitter_version`
+    and targets `core/tree-sitter-<ts_version>/bin` directly -- not the
+    `core/tree-sitter` symlink, which later per-directory calls can repoint.
+    """
+    with _stdout_to_stderr():
+        ug.ensure_tree_sitter_version(root, ts_version)
+    bin_dir = root / "core" / f"tree-sitter-{ts_version}" / "bin"
+    path_entries = os.environ.get("PATH", "").split(os.pathsep)
+    path_entries.insert(0, str(bin_dir))
+    os.environ["PATH"] = os.pathsep.join(path_entries)
 
 
 def run_update_grammar(language: str, ts_version: str, tag: str,
@@ -1041,6 +1077,12 @@ def main() -> int:
             return 1
         print(target.tag)
         return 0
+
+    # Every path below this point can shell out to test-lang/release/
+    # update-grammar, each of which invokes a bare `tree-sitter`. Put the
+    # right one on PATH once, globally, before any of them run.
+    if target.ts_version:
+        ensure_ts_version_on_path(root, target.ts_version)
 
     if args.release:
         return run_release(root, target, args.dry_run, result_file=args.result)

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -358,13 +358,7 @@ def _stdout_to_stderr():
 
 
 def ensure_ts_version_on_path(root: Path, ts_version: str) -> None:
-    """Put `ts_version`'s tree-sitter CLI on PATH, ahead of everything else.
-
-    test-lang, release, and update-grammar's own re-run all shell out to a
-    bare `tree-sitter`; CI sets this up via GITHUB_PATH, a local run
-    doesn't. Reuses update-grammar's self-healing `ensure_tree_sitter_version`
-    and targets `core/tree-sitter-<ts_version>/bin` directly -- not the
-    `core/tree-sitter` symlink, which later per-directory calls can repoint.
+    """Set up `ts_version`'s tree-sitter CLI and add it to PATH, ahead of everything else.
     """
     with _stdout_to_stderr():
         ug.ensure_tree_sitter_version(root, ts_version)


### PR DESCRIPTION
We update-grammar's `ensure_tree_sitter_version` (self-healing:
installs the pinned version if missing) and mutates `PATH,`right after resolving the
language's pinned version and before any of the above run. Every
subprocess spawned afterward inherits it, with priority over whatever
else was on PATH.

This allows regenerate_snapshots, `lang/test-lang`, `lang/release`, etc. all invoke a bare  
`tree-sitter` command relying on PATH. The scheduled workflow arranges a  
correct one via GITHUB_PATH; a local run has no such hook and hits a bare  
FileNotFoundError.

Validated by unit-testing `ensure_ts_version_on_path` directly against
all three pinned versions in this repo (0.20.8, 0.22.6, 0.26.3): each
correctly self-installs and resolves `tree-sitter --version` to the
requested version, taking priority over a decoy `tree-sitter` planted
earlier on PATH. Also confirmed end-to-end via `propose-grammar-update <lang> --dry-run` for grammars pinned to different tree-sitter versions
(e.g. ruby at 0.20.8, lua at 0.22.6, r bumped to 0.26.3), each generating
its extension grammar with the correct version per the build log's
`(tree-sitter X.Y.Z)` line.

This relates to LANG-576 but does NOT close it.

### Checklist

- [x] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)