### PR TITLE
Choose the right tree-sitter version per grammar dialect, incl. ABI 15 constraints

### DIFF
--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -74,10 +74,7 @@ def _load_update_grammar() -> Any:
 ug = _load_update_grammar()
 
 # `lang/ts_versions.py` resolves the tree-sitter version pinned for a given
-# grammar directory (lang/languages-*, lang/language-variants-*) -- the same
-# lookup the grammar Makefiles use via `lang/scripts/ts-version-for-grammar-dir`.
-# Reused here so regenerate_snapshots can catch a sub-dialect pinned to a
-# different tree-sitter version than the one its wrapper was just bumped to.
+# grammar directory (lang/languages-*, lang/language-variants-*).
 _TS_VERSIONS_PATH = _SCRIPT_DIR.parent / "lang" / "ts_versions.py"
 
 

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -73,6 +73,25 @@ def _load_update_grammar() -> Any:
 
 ug = _load_update_grammar()
 
+# `lang/ts_versions.py` resolves the tree-sitter version pinned for a given
+# grammar directory (lang/languages-*, lang/language-variants-*) -- the same
+# lookup the grammar Makefiles use via `lang/scripts/ts-version-for-grammar-dir`.
+# Reused here so regenerate_snapshots can catch a sub-dialect pinned to a
+# different tree-sitter version than the one its wrapper was just bumped to.
+_TS_VERSIONS_PATH = _SCRIPT_DIR.parent / "lang" / "ts_versions.py"
+
+
+def _load_ts_versions() -> Any:
+    """Load `lang/ts_versions.py` as an importable module."""
+    loader = SourceFileLoader("ts_versions", str(_TS_VERSIONS_PATH))
+    spec = spec_from_loader("ts_versions", loader)
+    module = module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+ts_versions = _load_ts_versions()
+
 ###############################################################################
 # Types #
 ###############################################################################
@@ -97,15 +116,25 @@ _STABLE_TAG_RE = re.compile(r"^v?\d+(?:\.\d+)+$")
 
 
 @dataclass(frozen=True)
-class Target:
-    """Everything needed to act on a language, resolved without mutating."""
+class LangAndWrapper:
     language: str
     wrapper: str
+
+    def wrapper_dir(self, root: Path) -> Path:
+        """Return the semgrep-<wrapper> directory under semgrep-grammars/src."""
+        return root / "lang" / "semgrep-grammars" / "src" / f"semgrep-{self.wrapper}"
+
+
+@dataclass(frozen=True)
+class Target:
+    """Everything needed to act on a language, resolved without mutating."""
+    lang: LangAndWrapper
     submodule: Path
     ts_version: str | None = None
     url: str | None = None
     tag: str | None = None
     skip_reason: str | None = None
+    resolution_note: str | None = None
 
 
 @dataclass
@@ -127,6 +156,7 @@ class Result:
     corpus_diff: str = ""
     tests_adapted: bool = False
     branch: str | None = None
+    version_note: str | None = None
 
     def to_json(self) -> str:
         return json.dumps({k: v for k, v in asdict(self).items() if v is not None})
@@ -218,61 +248,323 @@ def gitmodules_url(root: Path, submodule: Path) -> str | None:
     return url.replace("git@github.com:", "https://github.com/")
 
 
-def latest_stable_tag(url: str) -> str | None:
-    """Return the highest stable release tag at `url`, or None.
+# Cap on newer-than-current tags examined per language.
+MAX_TAGS_EXAMINED = 4
 
-    Lists remote tags, keeps only `_STABLE_TAG_RE` matches (so prereleases
-    and non-version tag schemes are ignored), and returns the highest by
-    numeric version.
+# tree-sitter >= 0.24 is known to break C++ external scanners (scanner.cc).
+_CPP_SCANNER_CEILING = version_key("0.24.0")
+_CPP_SCANNER_CEILING_STR = ".".join(str(part) for part in _CPP_SCANNER_CEILING)
+
+# ABI 15's only grammar-authoring feature that can't be expressed in ABI 14
+# (this repo ships ABI 14 only -- see lang/generate_abi_args.py).
+_RESERVED_FIELD_RE = re.compile(r"^\s*reserved\s*:", re.MULTILINE)
+
+# Semver inside a devDependencies/peerDependencies value, e.g. "^0.25.3".
+_VERSION_DIGITS_RE = re.compile(r"(\d+\.\d+\.\d+)")
+
+
+@dataclass(frozen=True)
+class FetchedSubmodule:
+    """A submodule whose tags (and full history) are available locally.
+
+    Construct only via `fetch` -- that unshallows and fetches tags, so
+    ancestry checks and `git show` against tags are valid on the result.
     """
-    result = git_query(["git", "ls-remote", "--tags", "--refs", url], cwd=Path.cwd())
+    path: Path
+
+    @classmethod
+    def fetch(cls, submodule: Path) -> FetchedSubmodule | None:
+        """Unshallow if needed, then fetch all tags. Never touches HEAD/worktree.
+
+        Mirrors update_submodule's fetch sequence so ancestry checks remain
+        valid. Returns None if the tag fetch fails.
+        """
+        if ug.is_shallow_repo(submodule):
+            git_query(["git", "fetch", "origin", "--unshallow"], cwd=submodule)
+        ok = git_query(
+            ["git", "fetch", "--tags", "origin"], cwd=submodule,
+        ).returncode == 0
+        return cls(submodule) if ok else None
+
+    def is_newer_than(self, tag: str, old_sha: str) -> bool:
+        """True if `old_sha` is an ancestor of `tag` -- i.e. `tag` is newer."""
+        tag_sha = git_query(
+            ["git", "rev-list", "-n", "1", tag], cwd=self.path,
+        ).stdout.strip()
+        return (tag_sha != old_sha and
+                git_query(
+                    ["git", "merge-base", "--is-ancestor", old_sha, tag],
+                    cwd=self.path,
+                ).returncode == 0)
+
+    def list_newer_stable_tags(
+        self, url: str, old_sha: str,
+    ) -> list[str] | None:
+        """Return stable tags at `url` strictly newer than `old_sha`, newest first.
+
+        Returns None if upstream has no stable tags at all
+        (distinct from an empty list = already current).
+        """
+        stable = _list_stable_tags(url)
+        if not stable:
+            return None
+        return [tag for tag in stable if self.is_newer_than(tag, old_sha)]
+
+    def read_tag_file(self, tag: str, path: str) -> str | None:
+        """Return the text of `path` at `tag` in this submodule, or None if absent.
+
+        `git show` reads straight from the object store -- never touches the
+        working tree.
+        """
+        result = git_query(["git", "show", f"{tag}:{path}"], cwd=self.path)
+        return result.stdout if result.returncode == 0 else None
+
+    def tag_has_path(self, tag: str, path: str) -> bool:
+        """True if `path` exists at `tag` in this submodule."""
+        return git_query(
+            ["git", "cat-file", "-e", f"{tag}:{path}"], cwd=self.path,
+        ).returncode == 0
+
+def _list_stable_tags(url: str) -> list[str]:
+    """Return every stable release tag at `url`, sorted newest first."""
+    # Patterns narrow the listing server-side; `_STABLE_TAG_RE` still drops
+    # prereleases (v1.0.0-rc1) that globs can't exclude.
+    result = git_query(
+        ["git", "ls-remote", "--tags", "--refs", url,
+         "refs/tags/v[0-9]*", "refs/tags/[0-9]*"],
+        cwd=Path.cwd(),
+    )
     if result.returncode != 0:
-        return None
+        return []
     tags = [
         line.split("refs/tags/", 1)[1]
         for line in result.stdout.splitlines()
         if "refs/tags/" in line
     ]
+    # We still need to filter here, because the above pattern
+    # does not filter pre-release tags.
     stable = [t for t in tags if _STABLE_TAG_RE.match(t)]
-    if not stable:
+    return sorted(stable, key=version_key, reverse=True)
+
+
+def latest_stable_tag(url: str) -> str | None:
+    """Return the highest stable release tag at `url`, or None."""
+    tags = _list_stable_tags(url)
+    return tags[0] if tags else None
+
+
+def _requires_abi15(fetched: FetchedSubmodule, tag: str) -> bool:
+    """True if the grammar at `tag` declares a top-level `reserved:` field.
+
+    Best-effort text check on `grammar.js` -- misses `reserved` declared
+    only in a shared/required module; test-lang is the authoritative check.
+    """
+    text = fetched.read_tag_file(tag, "grammar.js")
+    return bool(text and _RESERVED_FIELD_RE.search(text))
+
+
+def _upstream_has_cpp_scanner(fetched: FetchedSubmodule, tag: str) -> bool:
+    """True if upstream at `tag` ships a C++ external scanner (`src/scanner.cc`)."""
+    return fetched.tag_has_path(tag, "src/scanner.cc")
+
+
+def _semgrep_has_cpp_scanner(root: Path, lang: LangAndWrapper) -> bool:
+    """True if the semgrep extension grammar keeps a C++ scanner.
+
+    Checked on the working tree (`semgrep-<wrapper>/src/scanner.cc`): the
+    extension lives in this repo, not in the upstream submodule tag. A stale
+    C++ fork here (e.g. ruby) still forces tree-sitter < 0.24 even when
+    upstream has already moved to `scanner.c`.
+    """
+    return (lang.wrapper_dir(root) / "src" / "scanner.cc").is_file()
+
+
+def _declared_min_ts_version(fetched: FetchedSubmodule, tag: str) -> str | None:
+    """Return upstream's declared minimum tree-sitter-cli version at `tag`.
+
+    Parsed from package.json's devDependencies/peerDependencies. None if
+    undeclared, unparseable, or package.json is absent.
+    """
+    text = fetched.read_tag_file(tag, "package.json")
+    if not text:
         return None
-    return max(stable, key=version_key)
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError:
+        return None
+    for section in ("devDependencies", "peerDependencies"):
+        section_data = data.get(section)
+        if not isinstance(section_data, dict):
+            continue
+        spec = section_data.get("tree-sitter-cli")
+        if spec:
+            match = _VERSION_DIGITS_RE.search(spec)
+            if match:
+                return match.group(1)
+    return None
 
 
-def language_ts_version(root: Path, wrapper: str) -> str | None:
-    """Return the tree-sitter version `wrapper` is listed under, or None.
+@dataclass(frozen=True)
+class VersionResolution:
+    """Outcome of resolve_tag_and_version: a (tag, ts_version) pairing
+    (optionally with an advisory `note`), or an `error`."""
+    tag: str | None
+    ts_version: str | None
+    note: str | None = None
+    error: str | None = None
+
+
+def resolve_tag_and_version(root: Path, submodule: Path, url: str,
+                            tree_sitter_versions: list[str],
+                            old_sha: str, lang: LangAndWrapper) -> VersionResolution:
+    """Pick the newest tag newer than `old_sha` this repo can build at ABI
+    14, and the best pinned tree-sitter version to build it with.
+
+    Walks newer stable tags (capped at MAX_TAGS_EXAMINED), skips ABI 15,
+    and picks the highest pinned lang/languages-* version compatible with
+    C++-scanner constraints (upstream tag and/or semgrep-<wrapper>) and
+    upstream's declared tree-sitter-cli floor.
+    """
+
+    fetched = FetchedSubmodule.fetch(submodule)
+    if fetched is None:
+        return VersionResolution(None, None, error="could not fetch tags from submodule")
+
+    tags = fetched.list_newer_stable_tags(url, old_sha)
+    if tags is None:
+        return VersionResolution(None, None, error="no stable release tag upstream")
+    if not tags:
+        return VersionResolution(
+            None, None,
+            error="already at (or ahead of) the newest available upstream tag",
+        )
+
+    semgrep_cpp = _semgrep_has_cpp_scanner(root, lang)
+    reasons: list[str] = []
+    for tag in tags[:MAX_TAGS_EXAMINED]:
+        if _requires_abi15(fetched, tag):
+            reasons.append(
+                f"{tag}: requires ABI 15 (declares 'reserved:'); "
+                f"this repo builds ABI 14 only"
+            )
+            continue
+        upstream_cpp = _upstream_has_cpp_scanner(fetched, tag)
+        has_cpp = upstream_cpp or semgrep_cpp
+        floor = _declared_min_ts_version(fetched, tag)
+        fitting = [
+            v for v in tree_sitter_versions
+            if (not has_cpp or version_key(v) < _CPP_SCANNER_CEILING)
+            and (floor is None or version_key(v) >= version_key(floor))
+        ]
+        floor_relaxed = False
+        if not fitting and has_cpp and floor is not None:
+            # C++ scanners need tree-sitter < 0.24; upstream's declared
+            # floor may be >= 0.24. Prefer the hard C++ ceiling and surface
+            # the conflict in the note (e.g. ruby: semgrep scanner.cc vs
+            # upstream tree-sitter-cli ^0.24).
+            fitting = [
+                v for v in tree_sitter_versions
+                if version_key(v) < _CPP_SCANNER_CEILING
+            ]
+            floor_relaxed = bool(fitting)
+        if not fitting:
+            constraints = []
+            if has_cpp:
+                constraints.append(
+                    f"C++ scanner (needs tree-sitter < {_CPP_SCANNER_CEILING_STR})"
+                )
+            if floor:
+                constraints.append(f"upstream's declared minimum {floor}")
+            reasons.append(
+                f"{tag}: no pinned tree-sitter version satisfies "
+                + " and ".join(constraints)
+            )
+            continue
+        chosen = fitting[0]
+        note = None
+        if has_cpp:
+            if semgrep_cpp and not upstream_cpp:
+                # Upstream moved to scanner.c but our extension still has
+                # scanner.cc -- call that out so it isn't mistaken for an
+                # upstream constraint.
+                note = (
+                    f"capped to {chosen}: semgrep-{lang.wrapper}/src/scanner.cc is "
+                    f"still C++ while upstream {tag} has no scanner.cc; "
+                    f"requires tree-sitter < {_CPP_SCANNER_CEILING_STR}. "
+                    f"Port or replace the semgrep scanner (or move the "
+                    f"ellipsis feature into grammar.js) to unlock newer "
+                    f"tree-sitter."
+                )
+            else:
+                where = "upstream" if upstream_cpp else f"semgrep-{lang.wrapper}"
+                note = (
+                    f"capped to {chosen}: C++ external scanner (scanner.cc) "
+                    f"in {where} requires tree-sitter < {_CPP_SCANNER_CEILING_STR}"
+                )
+            if floor_relaxed:
+                note = (
+                    f"{note} Upstream declares tree-sitter-cli >= {floor}, "
+                    f"which conflicts with the C++ scanner ceiling; kept the "
+                    f"ceiling."
+                )
+        return VersionResolution(tag, chosen, note=note)
+
+    detail = "; ".join(reasons) or "no compatible tag/tree-sitter-version pairing found"
+    return VersionResolution(None, None, error=detail)
+
+
+def language_ts_version(root: Path, lang: LangAndWrapper) -> str | None:
+    """Return the tree-sitter version `lang.wrapper` is listed under, or None.
 
     Scans each `lang/languages-<version>` file for the wrapper name. A
     language appears in exactly one; returns that version string.
     """
     version_files = ug.discover_version_files(root, "languages")
     for version, path in version_files.items():
-        if wrapper in ug.read_languages_entries(path):
+        if lang.wrapper in ug.read_languages_entries(path):
             return version
     return None
 
 
-def resolve_target(root: Path, language: str) -> Target:
-    """Resolve a `Target` for `language` without mutating anything.
+def resolve_target(root: Path, lang: LangAndWrapper, tree_sitter_versions: list[str], *, deep: bool = True) -> Target:
+    """Resolve a `Target` for `lang` without mutating anything.
 
-    Dies via update-grammar's `validate_language` on an unknown language.
+    `deep=True` (default -- the real propose flow) resolves both tag and
+    tree-sitter version via `resolve_tag_and_version`. `deep=False` (the
+    cheap `is_up_to_date` pre-filter, run across every language) resolves
+    only the single latest tag via one `ls-remote`, reusing the current pin.
     """
-    valid = ug.discover_valid_languages(root)
-    wrapper = ug.validate_language(language, valid)
-    submodule = ug.submodule_path(root, language)
+    submodule = ug.submodule_path(root, lang.language)
     url = gitmodules_url(root, submodule)
     # Languages absent from every languages-* file (e.g. gomod, a "pro"
     # package handled outside the standard version scheme) aren't
     # proposable via this flow; surface that as skip_reason rather than
     # dying, so callers can record it and move on.
-    ts_version = language_ts_version(root, wrapper)
+    current_ts_version = language_ts_version(root, lang)
     skip_reason = None
-    if ts_version is None:
-        skip_reason = f"'{wrapper}' is not in any lang/languages-* file"
-    tag = latest_stable_tag(url) if url else None
+    if current_ts_version is None:
+        skip_reason = f"'{lang.wrapper}' is not in any lang/languages-* file"
+
+    tag = ts_version = resolution_note = None
+    if skip_reason is None and url:
+        if deep:
+            old_sha = submodule_head(submodule)
+            resolution = resolve_tag_and_version(
+                root, submodule, url, tree_sitter_versions, old_sha, lang
+            )
+            tag, ts_version, resolution_note = (
+                resolution.tag, resolution.ts_version, resolution.note,
+            )
+            if resolution.error:
+                skip_reason = resolution.error
+        else:
+            tag = latest_stable_tag(url)
+            ts_version = current_ts_version
+
     return Target(
-        language=language, wrapper=wrapper, submodule=submodule,
+        lang=lang, submodule=submodule,
         ts_version=ts_version, url=url, tag=tag, skip_reason=skip_reason,
+        resolution_note=resolution_note,
     )
 
 
@@ -317,14 +609,14 @@ def tag_commit_sha(url: str, tag: str) -> str | None:
     return peeled or plain
 
 
-def is_up_to_date(root: Path, language: str) -> bool | None:
-    """True if `language`'s submodule is already at its latest stable tag.
+def is_up_to_date(root: Path, lang: LangAndWrapper) -> bool | None:
+    """True if `lang`'s submodule is already at its latest stable tag.
 
     Cheap: reads the recorded gitlink + a remote ls-remote, no build/checkout.
     Returns None if it can't be determined (no tag / no url) so callers can
     fall back to attempting the bump rather than wrongly skipping.
     """
-    target = resolve_target(root, language)
+    target = resolve_target(root, lang, tree_sitter_versions=[], deep=False)
     if target.skip_reason or target.tag is None or not target.url:
         return None
     cur = recorded_submodule_sha(root, target.submodule)
@@ -332,11 +624,6 @@ def is_up_to_date(root: Path, language: str) -> bool | None:
     if cur is None or tag_sha is None:
         return None
     return cur == tag_sha
-
-
-def wrapper_dir(root: Path, wrapper: str) -> Path:
-    """Return the semgrep-<wrapper> directory under semgrep-grammars/src."""
-    return root / "lang" / "semgrep-grammars" / "src" / f"semgrep-{wrapper}"
 
 
 @contextlib.contextmanager
@@ -358,8 +645,7 @@ def _stdout_to_stderr():
 
 
 def ensure_ts_version_on_path(root: Path, ts_version: str) -> None:
-    """Set up `ts_version`'s tree-sitter CLI and add it to PATH, ahead of everything else.
-    """
+    """Set up `ts_version`'s tree-sitter CLI and add it to PATH, ahead of everything else."""
     with _stdout_to_stderr():
         ug.ensure_tree_sitter_version(root, ts_version)
     bin_dir = root / "core" / f"tree-sitter-{ts_version}" / "bin"
@@ -368,7 +654,7 @@ def ensure_ts_version_on_path(root: Path, ts_version: str) -> None:
     os.environ["PATH"] = os.pathsep.join(path_entries)
 
 
-def run_update_grammar(language: str, ts_version: str, tag: str,
+def run_update_grammar(lang: LangAndWrapper, ts_version: str, tag: str,
                        root: Path) -> subprocess.CompletedProcess:
     """Bump `language` to `tag` via `update-grammar --skip-release`.
 
@@ -377,43 +663,55 @@ def run_update_grammar(language: str, ts_version: str, tag: str,
     --skip-release guarantees nothing is pushed to semgrep-<lang>.
     """
     return subprocess.run(
-        [str(_UPDATE_GRAMMAR_PATH), language, ts_version,
+        [str(_UPDATE_GRAMMAR_PATH), lang.language, ts_version,
          "--ref", tag, "--skip-release"],
         cwd=root, text=True, capture_output=True, check=False,
     )
 
 
-def regenerate_snapshots(root: Path, wrapper: str) -> None:
+def regenerate_snapshots(root: Path, lang: LangAndWrapper, ts_version: str) -> None:
     """Regenerate corpus snapshots for every grammar in the wrapper.
 
     A grammar bump almost always churns parse trees, so the committed
     corpus snapshots go stale. `tree-sitter test --update` rewrites them
     from the new parser. Runs in each dir containing a grammar.js (the
     base grammar plus any sub-grammars). Requires core/tree-sitter/bin on
-    PATH (the workflow guarantees this). `:error` tests are left untouched
-    by --update; if any still fail, the later test-lang re-run catches it.
+    PATH (`ensure_ts_version_on_path`, called by main(), guarantees this).
+    Every grammar.js under a wrapper is expected to be pinned to the same
+    `ts_version` the wrapper was just bumped to; a sub-dialect pinned to a
+    different one is a real inconsistency that must be reported, not
+    silently tested against the wrong tree-sitter CLI. `:error` tests are
+    left untouched by --update; if any still fail, the later test-lang
+    re-run catches it.
     """
-    wrapper_path = wrapper_dir(root, wrapper)
+    wrapper_path = lang.wrapper_dir(root)
     grammar_dirs = {p.parent for p in wrapper_path.rglob("grammar.js")}
     for gdir in sorted(grammar_dirs):
+        pinned = ts_versions.version_for_grammar_dir(gdir, root / "lang")
+        if pinned != ts_version:
+            raise ts_versions.TsVersionError(
+                f"{gdir} is pinned to tree-sitter {pinned}, but {lang.wrapper} "
+                f"was bumped to {ts_version}; a sub-dialect diverging from "
+                f"its wrapper's tree-sitter version is not supported"
+            )
         # check=False: --update exits non-zero on :error tests it can't
         # update; that's expected and handled by the authoritative
         # test-lang re-run.
         git_query(["tree-sitter", "test", "--update"], cwd=gdir)
 
 
-def corpus_diff(root: Path, wrapper: str) -> str:
+def corpus_diff(root: Path, lang: LangAndWrapper) -> str:
     """Return the working-tree diff of the wrapper's corpus snapshots."""
     return git_query(
-        ["git", "diff", "--", str(wrapper_dir(root, wrapper) / "test" / "corpus")],
+        ["git", "diff", "--", str(lang.wrapper_dir(root) / "test" / "corpus")],
         cwd=root,
     ).stdout
 
 
-def run_test_lang(language: str, root: Path) -> subprocess.CompletedProcess:
+def run_test_lang(lang: LangAndWrapper, root: Path) -> subprocess.CompletedProcess:
     """Run `./test-lang <language>` for the authoritative pass/fail."""
     return subprocess.run(
-        ["./test-lang", language], cwd=root / "lang",
+        ["./test-lang", lang.language], cwd=root / "lang",
         text=True, capture_output=True, check=False,
     )
 
@@ -452,13 +750,13 @@ def base_branch() -> str:
     return base
 
 
-def branch_name(language: str, tag: str) -> str:
+def branch_name(lang: LangAndWrapper, tag: str) -> str:
     """Branch for a lang+tag proposal.
 
     Keyed on the exact tag (not the CI user) so re-runs on the same
     schedule are idempotent and a new upstream tag yields a new branch.
     """
-    return f"grammar-update/{language}/{tag}"
+    return f"grammar-update/{lang.language}/{tag}"
 
 
 def proposal_exists(root: Path, branch: str) -> bool:
@@ -488,10 +786,10 @@ def existing_proposal(root: Path, target: Target) -> Result | None:
     """
     if target.tag is None:
         return None
-    branch = branch_name(target.language, target.tag)
+    branch = branch_name(target.lang, target.tag)
     if not proposal_exists(root, branch):
         return None
-    return Result(language=target.language, ts_version=target.ts_version,
+    return Result(language=target.lang.language, ts_version=target.ts_version,
                   new_tag=target.tag, status=STATUS_EXISTS, branch=branch,
                   detail=f"branch {branch} already exists")
 
@@ -523,6 +821,10 @@ def pr_body(result: Result, url: str) -> str:
         "Scrutinize the test changes in the diff.\n\n"
         if result.tests_adapted else ""
     )
+    version_note = (
+        f"> ℹ️ **Tree-sitter version note:** {result.version_note}\n\n"
+        if result.version_note else ""
+    )
     return (
         f"Automated grammar update for **{result.language}**.\n\n"
         f"- Upstream: {url}\n"
@@ -532,6 +834,7 @@ def pr_body(result: Result, url: str) -> str:
         f"Corpus snapshots were auto-regenerated. **Please review** the parse-tree "
         f"changes below — especially any `:error` (error-recovery) cases, which "
         f"`tree-sitter test --update` does not touch automatically.\n\n"
+        f"{version_note}"
         f"{adapted_note}"
         f"{diff_section}\n\n{log_section}\n\n"
         f"🤖 Generated with [Claude Code](https://claude.com/claude-code)"
@@ -549,11 +852,11 @@ def open_pr(root: Path, target: Target, result: Result,
     (created + committed by propose in keep mode) — here we only push it and
     open the PR. Idempotent: skips if a branch already exists upstream.
     """
-    language, tag = target.language, result.new_tag
+    lang, tag = target.lang, result.new_tag
     base = base_branch()
-    branch = result.branch or branch_name(language, tag)
+    branch = result.branch or branch_name(lang, tag)
     result.branch = branch
-    title = f"Update tree-sitter-{language} grammar to {tag}"
+    title = f"Update tree-sitter-{lang.language} grammar to {tag}"
     body = pr_body(result, target.url)
 
     if dry_run:
@@ -579,7 +882,7 @@ def open_pr(root: Path, target: Target, result: Result,
     return result
 
 
-def review_agent_prompt(language: str, wrapper: str, tag: str,
+def review_agent_prompt(lang: LangAndWrapper, tag: str,
                         test_log: str) -> str:
     """Prompt that drives Marc-André's `fix-semgrep-grammar` skill.
 
@@ -592,8 +895,8 @@ def review_agent_prompt(language: str, wrapper: str, tag: str,
     signal remains the test-lang RE-RUN the caller does afterward.
     """
     return (
-        f"Use the `fix-semgrep-grammar` skill to make `test-lang {language}` "
-        f"pass. Context: the tree-sitter-{language} submodule was just bumped "
+        f"Use the `fix-semgrep-grammar` skill to make `test-lang {lang.language}` "
+        f"pass. Context: the tree-sitter-{lang.language} submodule was just bumped "
         f"to {tag} and test-lang now fails. Follow the skill's edit boundaries "
         f"and exit contract exactly; do not commit, push, or open a PR — leave "
         f"the working tree changed for the outer pipeline. Print the skill's "
@@ -623,7 +926,7 @@ def agent_cmd(prompt: str) -> list[str]:
     return ["timeout", limit, *cmd]
 
 
-def run_review_agent(root: Path, language: str, wrapper: str, tag: str,
+def run_review_agent(root: Path, lang: LangAndWrapper, tag: str,
                      test_log: str) -> None:
     """Invoke the Cursor agent to review + adapt tests for a failing bump.
 
@@ -631,8 +934,8 @@ def run_review_agent(root: Path, language: str, wrapper: str, tag: str,
     Best-effort: the authoritative signal is the test-lang RE-RUN the
     caller does afterward, so we don't raise on the agent's own exit code.
     """
-    prompt = review_agent_prompt(language, wrapper, tag, test_log)
-    log(f"$ agent -p --force <review prompt for {language}>  (in {root})")
+    prompt = review_agent_prompt(lang, tag, test_log)
+    log(f"$ agent -p --force <review prompt for {lang.language}>  (in {root})")
     r = subprocess.run(agent_cmd(prompt), cwd=root, text=True,
                        capture_output=True, check=False)
     sys.stderr.write(r.stdout)
@@ -655,10 +958,11 @@ def propose(root: Path, target: Target, keep: bool = False,
     is reset before returning.
     Does NOT create a PR — that's the caller's job under --open-pr.
     """
-    language = target.language
+    lang = target.lang
     tag = target.tag
-    wrapper = target.wrapper
-    result = Result(language=language, ts_version=target.ts_version, new_tag=tag)
+    result = Result(language=lang.language, ts_version=target.ts_version, new_tag=tag)
+    if target.resolution_note:
+        result.version_note = target.resolution_note
 
     if target.skip_reason:
         result.status = STATUS_NO_TAGS
@@ -679,7 +983,7 @@ def propose(root: Path, target: Target, keep: bool = False,
     # do the work in place and reset the tree before returning. Doing it once,
     # on the final branch, avoids the old propose-resets/open_pr-redoes
     # duplication (and the second, unvalidated agent run it caused).
-    branch = branch_name(language, tag)
+    branch = branch_name(lang, tag)
     committed = False
     if keep:
         base = base_branch()
@@ -692,7 +996,7 @@ def propose(root: Path, target: Target, keep: bool = False,
         # our re-run below is the authoritative signal. But an unchanged
         # submodule is only a real no-op if the bump itself succeeded —
         # otherwise it failed before doing anything and must be surfaced.
-        bump = run_update_grammar(language, target.ts_version, tag, root)
+        bump = run_update_grammar(lang, target.ts_version, tag, root)
         new_sha = submodule_head(submodule)
         result.new_sha = new_sha
 
@@ -707,9 +1011,9 @@ def propose(root: Path, target: Target, keep: bool = False,
 
         # Snapshots are expected to churn; regenerate then test for the
         # authoritative result.
-        regenerate_snapshots(root, wrapper)
-        result.corpus_diff = corpus_diff(root, wrapper)
-        test = run_test_lang(language, root)
+        regenerate_snapshots(root, lang, target.ts_version)
+        result.corpus_diff = corpus_diff(root, lang)
+        test = run_test_lang(lang, root)
         result.test_log_tail = tail(test.stdout + test.stderr)
 
         if test.returncode != 0 and review_agent:
@@ -717,10 +1021,10 @@ def propose(root: Path, target: Target, keep: bool = False,
             # that broke existing corpus snapshots. Invoke the fix-semgrep-
             # grammar skill to adapt the tests, then re-test as the
             # authoritative signal (the skill's own status is advisory).
-            run_review_agent(root, language, wrapper, tag,
+            run_review_agent(root, lang, tag,
                              test.stdout + test.stderr)
-            result.corpus_diff = corpus_diff(root, wrapper)
-            test = run_test_lang(language, root)
+            result.corpus_diff = corpus_diff(root, lang)
+            test = run_test_lang(lang, root)
             result.test_log_tail = tail(test.stdout + test.stderr)
             if test.returncode == 0:
                 result.tests_adapted = True
@@ -742,7 +1046,7 @@ def propose(root: Path, target: Target, keep: bool = False,
             run_quiet(["git", "add", "-A", "--", ".",
                        ":(exclude)result-*.json", ":(exclude)core"], cwd=root)
             run_quiet(["git", "commit", "-m",
-                       f"Update tree-sitter-{language} grammar to {tag}"], cwd=root)
+                       f"Update tree-sitter-{lang.language} grammar to {tag}"], cwd=root)
             committed = True
             result.branch = branch
         return result
@@ -802,7 +1106,7 @@ def ensure_label(repo: str, label: str) -> None:
     )
 
 
-def release_dialects(language: str, wrapper: str) -> list[str]:
+def release_dialects(lang: LangAndWrapper) -> list[str]:
     """Dialects to release for a language, filtered to existing repos.
 
     `lang/release` operates per dialect (typescript -> [typescript, tsx],
@@ -810,9 +1114,9 @@ def release_dialects(language: str, wrapper: str) -> list[str]:
     semgrep-<dialect> repo can be released. Falls back to the language
     itself.
     """
-    dialects = ug.LANGUAGE_VARIANTS.get(wrapper, [language])
+    dialects = ug.LANGUAGE_VARIANTS.get(lang.wrapper, [lang.language])
     existing = [d for d in dialects if downstream_repo_exists(d)]
-    return existing or [language]
+    return existing or [lang.language]
 
 
 def open_downstream_pr(dialect: str, branch: str, tag: str,
@@ -846,7 +1150,7 @@ def open_downstream_pr(dialect: str, branch: str, tag: str,
     )
 
 
-def release_downstream(root: Path, language: str, wrapper: str, branch: str,
+def release_downstream(root: Path, lang: LangAndWrapper, branch: str,
                        tag: str, *, dry_run: bool) -> subprocess.CompletedProcess:
     """Release the generated parser to each semgrep-<dialect> repo, via PR.
 
@@ -858,7 +1162,7 @@ def release_downstream(root: Path, language: str, wrapper: str, branch: str,
     """
     lang_dir = root / "lang"
     last = None
-    for dialect in release_dialects(language, wrapper):
+    for dialect in release_dialects(lang):
         cmd = ["./release", dialect, "--branch", branch]
         if dry_run:
             cmd.append("--dry-run")
@@ -890,11 +1194,13 @@ def list_languages(root: Path, as_json: bool, updatable_only: bool = False) -> N
     Languages whose status can't be cheaply determined are INCLUDED (so the
     full flow decides, rather than wrongly skipping them).
     """
-    names = sorted(ug.discover_valid_languages(root))
+    valid = ug.discover_valid_languages(root)
+    names = sorted(valid)
     if updatable_only:
         kept = []
         for name in names:
-            up = is_up_to_date(root, name)
+            lang = LangAndWrapper(language=name, wrapper=valid[name])
+            up = is_up_to_date(root, lang)
             if up is True:
                 log(f"skip {name}: already at latest tag")
             else:
@@ -1015,14 +1321,14 @@ def run_release(root: Path, target: Target, dry_run: bool,
     live, and a stale branch name fails loudly on the fetch (no silent
     wrong-version release).
     """
-    language, wrapper = target.language, target.wrapper
+    language, wrapper = target.lang.language, target.lang.wrapper
     if result_file:
         res = Result.from_file(Path(result_file))
         tag = res.new_tag
-        branch = res.branch or (branch_name(language, tag) if tag else None)
+        branch = res.branch or (branch_name(target.lang, tag) if tag else None)
     else:
         tag = target.tag
-        branch = branch_name(language, tag) if tag else None
+        branch = branch_name(target.lang, tag) if tag else None
     if tag is None or branch is None:
         ug.die(f"{language}: no validated tag/branch; nothing to release.")
 
@@ -1036,7 +1342,7 @@ def run_release(root: Path, target: Target, dry_run: bool,
     run_quiet(["git", "submodule", "update", "--init", "--recursive", "--depth", "1",
                "--", str(target.submodule.relative_to(root))], cwd=root)
 
-    rel = release_downstream(root, language, wrapper, branch, tag, dry_run=dry_run)
+    rel = release_downstream(root, target.lang, branch, tag, dry_run=dry_run)
     if rel is not None and rel.returncode != 0:
         ug.die(f"{language}: lang/release failed.")
 
@@ -1063,11 +1369,24 @@ def main() -> int:
     if not args.language:
         ug.die("a language is required (or use --list-languages).")
 
-    target = resolve_target(root, args.language)
+    tree_sitter_versions = sorted(
+        ug.discover_version_files(root, "languages").keys(),
+        key=version_key, reverse=True,
+    )
+    if not tree_sitter_versions:
+        ug.die("no supported tree-sitter versions found in lang/languages-* files")
+
+    # Dies if the language is unknown.
+    valid = ug.discover_valid_languages(root)
+    wrapper = ug.validate_language(args.language, valid)
+
+    # Determine what to update the language to.
+    lang = LangAndWrapper(language=args.language, wrapper=wrapper)
+    target = resolve_target(root, lang, tree_sitter_versions)
 
     if args.resolve_tag_only:
         if target.tag is None:
-            log(f"{args.language}: no stable release tag found.")
+            log(f"{lang.language}: no stable release tag found.")
             return 1
         print(target.tag)
         return 0

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -51,6 +51,8 @@ from importlib.util import module_from_spec, spec_from_loader
 from pathlib import Path
 from typing import Any
 
+from packaging.version import Version
+
 ###############################################################################
 # update-grammar import #
 ###############################################################################
@@ -252,8 +254,8 @@ def gitmodules_url(root: Path, submodule: Path) -> str | None:
 MAX_TAGS_EXAMINED = 4
 
 # tree-sitter >= 0.24 is known to break C++ external scanners (scanner.cc).
-_CPP_SCANNER_CEILING = version_key("0.24.0")
-_CPP_SCANNER_CEILING_STR = ".".join(str(part) for part in _CPP_SCANNER_CEILING)
+_CPP_SCANNER_CEILING = Version("0.24.0")
+_CPP_SCANNER_CEILING_STR = str(_CPP_SCANNER_CEILING)
 
 # ABI 15's only grammar-authoring feature that can't be expressed in ABI 14
 # (this repo ships ABI 14 only -- see lang/generate_abi_args.py).
@@ -261,6 +263,20 @@ _RESERVED_FIELD_RE = re.compile(r"^\s*reserved\s*:", re.MULTILINE)
 
 # Semver inside a devDependencies/peerDependencies value, e.g. "^0.25.3".
 _VERSION_DIGITS_RE = re.compile(r"(\d+\.\d+\.\d+)")
+
+
+@dataclass(frozen=True)
+class NoStableTags:
+    """Upstream has no stable release tags at all."""
+
+
+@dataclass(frozen=True)
+class NewerStableTags:
+    """Stable tags strictly newer than the current SHA, newest first.
+
+    An empty `tags` list means already at (or ahead of) the newest stable tag.
+    """
+    tags: list[str]
 
 
 @dataclass(frozen=True)
@@ -299,16 +315,18 @@ class FetchedSubmodule:
 
     def list_newer_stable_tags(
         self, url: str, old_sha: str,
-    ) -> list[str] | None:
+    ) -> NoStableTags | NewerStableTags:
         """Return stable tags at `url` strictly newer than `old_sha`, newest first.
 
-        Returns None if upstream has no stable tags at all
-        (distinct from an empty list = already current).
+        `NoStableTags` if upstream has no stable tags at all;
+        `NewerStableTags` with an empty list means already current.
         """
         stable = _list_stable_tags(url)
         if not stable:
-            return None
-        return [tag for tag in stable if self.is_newer_than(tag, old_sha)]
+            return NoStableTags()
+        return NewerStableTags(
+            [tag for tag in stable if self.is_newer_than(tag, old_sha)]
+        )
 
     def read_tag_file(self, tag: str, path: str) -> str | None:
         """Return the text of `path` at `tag` in this submodule, or None if absent.
@@ -324,6 +342,7 @@ class FetchedSubmodule:
         return git_query(
             ["git", "cat-file", "-e", f"{tag}:{path}"], cwd=self.path,
         ).returncode == 0
+
 
 def _list_stable_tags(url: str) -> list[str]:
     """Return every stable release tag at `url`, sorted newest first."""
@@ -405,17 +424,125 @@ def _declared_min_ts_version(fetched: FetchedSubmodule, tag: str) -> str | None:
 
 
 @dataclass(frozen=True)
-class VersionResolution:
-    """Outcome of resolve_tag_and_version: a (tag, ts_version) pairing
-    (optionally with an advisory `note`), or an `error`."""
-    tag: str | None
-    ts_version: str | None
+class VersionOk:
+    """Successful resolve_tag_and_version outcome."""
+    tag: str
+    ts_version: str
     note: str | None = None
-    error: str | None = None
+
+
+@dataclass(frozen=True)
+class VersionErr:
+    """Failed resolve_tag_and_version outcome."""
+    error: str
+
+
+VersionResolution = VersionOk | VersionErr
+
+
+def _pick_ts_version(
+    versions: list[Version], *, floor: Version | None, ceiling: Version | None,
+) -> Version | None:
+    """Return the newest fitting pinned version, or None if nothing fits.
+
+    `versions` must already be parsed `Version`s, newest-first.
+    """
+    for v in versions:
+        if ceiling is not None and not v < ceiling:
+            continue
+        if floor is not None and not v >= floor:
+            continue
+        return v
+    return None
+
+
+def _version_note(
+    lang: LangAndWrapper, tag: str, chosen: Version, *,
+    upstream_cpp: bool, semgrep_cpp: bool,
+    floor: Version | None,
+) -> str | None:
+    """Advisory note when the chosen pin is constrained (C++ scanner, etc.)."""
+    has_cpp = upstream_cpp or semgrep_cpp
+    if not has_cpp:
+        return None
+    if semgrep_cpp and not upstream_cpp:
+        # Upstream moved to scanner.c but our extension still has
+        # scanner.cc -- call that out so it isn't mistaken for an
+        # upstream constraint.
+        note = (
+            f"capped to {chosen}: semgrep-{lang.wrapper}/src/scanner.cc is "
+            f"still C++ while upstream {tag} has no scanner.cc; "
+            f"requires tree-sitter < {_CPP_SCANNER_CEILING_STR}. "
+            f"Port or replace the semgrep scanner (or move the "
+            f"ellipsis feature into grammar.js) to unlock newer "
+            f"tree-sitter."
+        )
+    else:
+        where = "upstream" if upstream_cpp else f"semgrep-{lang.wrapper}"
+        note = (
+            f"capped to {chosen}: C++ external scanner (scanner.cc) "
+            f"in {where} requires tree-sitter < {_CPP_SCANNER_CEILING_STR}"
+        )
+    # Stale semgrep .cc forces < 0.24 while upstream may declare >= 0.24;
+    # we ignored that floor when picking -- surface the conflict here.
+    if (
+        semgrep_cpp and not upstream_cpp and floor is not None
+        and chosen < floor
+    ):
+        note = (
+            f"{note} Upstream declares tree-sitter-cli >= {floor}, "
+            f"which conflicts with the C++ scanner ceiling; kept the "
+            f"ceiling."
+        )
+    return note
+
+
+def _evaluate_tag(
+    fetched: FetchedSubmodule, tag: str, tree_sitter_versions: list[Version],
+    *, semgrep_cpp: bool, lang: LangAndWrapper,
+) -> VersionOk | str:
+    """Try one tag: return VersionOk on success, or a skip-reason string."""
+    if _requires_abi15(fetched, tag):
+        return (
+            f"{tag}: requires ABI 15 (declares 'reserved:'); "
+            f"this repo builds ABI 14 only"
+        )
+    upstream_cpp = _upstream_has_cpp_scanner(fetched, tag)
+    has_cpp = upstream_cpp or semgrep_cpp
+    floor_str = _declared_min_ts_version(fetched, tag)
+    floor = Version(floor_str) if floor_str else None
+    # Only a stale semgrep .cc can force < 0.24 while upstream declares
+    # >= 0.24 (upstream cannot ship .cc at that floor). Ignore the floor
+    # so we can still propose under the C++ ceiling.
+    effective_floor = None if (semgrep_cpp and not upstream_cpp) else floor
+    effective_ceiling = _CPP_SCANNER_CEILING if has_cpp else None
+    chosen = _pick_ts_version(
+        tree_sitter_versions, floor=effective_floor, ceiling=effective_ceiling,
+    )
+    if chosen is None:
+        constraints = []
+        if has_cpp:
+            constraints.append(
+                f"C++ scanner (needs tree-sitter < {_CPP_SCANNER_CEILING_STR})"
+            )
+        if effective_floor is not None:
+            constraints.append(
+                f"upstream's declared minimum {effective_floor}"
+            )
+        return (
+            f"{tag}: no pinned tree-sitter version satisfies "
+            + " and ".join(constraints)
+        )
+    note = _version_note(
+        lang, tag, chosen,
+        upstream_cpp=upstream_cpp, semgrep_cpp=semgrep_cpp,
+        floor=floor,
+    )
+    return VersionOk(tag, str(chosen), note=note)
 
 
 def resolve_tag_and_version(root: Path, submodule: Path, url: str,
-                            tree_sitter_versions: list[str],
+                            tree_sitter_versions: list[Version],
                             old_sha: str, lang: LangAndWrapper) -> VersionResolution:
     """Pick the newest tag newer than `old_sha` this repo can build at ABI
     14, and the best pinned tree-sitter version to build it with.
@@ -425,92 +552,31 @@ def resolve_tag_and_version(root: Path, submodule: Path, url: str,
     C++-scanner constraints (upstream tag and/or semgrep-<wrapper>) and
     upstream's declared tree-sitter-cli floor.
     """
-
     fetched = FetchedSubmodule.fetch(submodule)
     if fetched is None:
-        return VersionResolution(None, None, error="could not fetch tags from submodule")
+        return VersionErr("could not fetch tags from submodule")
 
-    tags = fetched.list_newer_stable_tags(url, old_sha)
-    if tags is None:
-        return VersionResolution(None, None, error="no stable release tag upstream")
-    if not tags:
-        return VersionResolution(
-            None, None,
-            error="already at (or ahead of) the newest available upstream tag",
+    newer = fetched.list_newer_stable_tags(url, old_sha)
+    if isinstance(newer, NoStableTags):
+        return VersionErr("no stable release tag upstream")
+    if not newer.tags:
+        return VersionErr(
+            "already at (or ahead of) the newest available upstream tag",
         )
 
     semgrep_cpp = _semgrep_has_cpp_scanner(root, lang)
     reasons: list[str] = []
-    for tag in tags[:MAX_TAGS_EXAMINED]:
-        if _requires_abi15(fetched, tag):
-            reasons.append(
-                f"{tag}: requires ABI 15 (declares 'reserved:'); "
-                f"this repo builds ABI 14 only"
-            )
-            continue
-        upstream_cpp = _upstream_has_cpp_scanner(fetched, tag)
-        has_cpp = upstream_cpp or semgrep_cpp
-        floor = _declared_min_ts_version(fetched, tag)
-        fitting = [
-            v for v in tree_sitter_versions
-            if (not has_cpp or version_key(v) < _CPP_SCANNER_CEILING)
-            and (floor is None or version_key(v) >= version_key(floor))
-        ]
-        floor_relaxed = False
-        if not fitting and has_cpp and floor is not None:
-            # C++ scanners need tree-sitter < 0.24; upstream's declared
-            # floor may be >= 0.24. Prefer the hard C++ ceiling and surface
-            # the conflict in the note (e.g. ruby: semgrep scanner.cc vs
-            # upstream tree-sitter-cli ^0.24).
-            fitting = [
-                v for v in tree_sitter_versions
-                if version_key(v) < _CPP_SCANNER_CEILING
-            ]
-            floor_relaxed = bool(fitting)
-        if not fitting:
-            constraints = []
-            if has_cpp:
-                constraints.append(
-                    f"C++ scanner (needs tree-sitter < {_CPP_SCANNER_CEILING_STR})"
-                )
-            if floor:
-                constraints.append(f"upstream's declared minimum {floor}")
-            reasons.append(
-                f"{tag}: no pinned tree-sitter version satisfies "
-                + " and ".join(constraints)
-            )
-            continue
-        chosen = fitting[0]
-        note = None
-        if has_cpp:
-            if semgrep_cpp and not upstream_cpp:
-                # Upstream moved to scanner.c but our extension still has
-                # scanner.cc -- call that out so it isn't mistaken for an
-                # upstream constraint.
-                note = (
-                    f"capped to {chosen}: semgrep-{lang.wrapper}/src/scanner.cc is "
-                    f"still C++ while upstream {tag} has no scanner.cc; "
-                    f"requires tree-sitter < {_CPP_SCANNER_CEILING_STR}. "
-                    f"Port or replace the semgrep scanner (or move the "
-                    f"ellipsis feature into grammar.js) to unlock newer "
-                    f"tree-sitter."
-                )
-            else:
-                where = "upstream" if upstream_cpp else f"semgrep-{lang.wrapper}"
-                note = (
-                    f"capped to {chosen}: C++ external scanner (scanner.cc) "
-                    f"in {where} requires tree-sitter < {_CPP_SCANNER_CEILING_STR}"
-                )
-            if floor_relaxed:
-                note = (
-                    f"{note} Upstream declares tree-sitter-cli >= {floor}, "
-                    f"which conflicts with the C++ scanner ceiling; kept the "
-                    f"ceiling."
-                )
-        return VersionResolution(tag, chosen, note=note)
+    for tag in newer.tags[:MAX_TAGS_EXAMINED]:
+        outcome = _evaluate_tag(
+            fetched, tag, tree_sitter_versions,
+            semgrep_cpp=semgrep_cpp, lang=lang,
+        )
+        if isinstance(outcome, VersionOk):
+            return outcome
+        reasons.append(outcome)
 
     detail = "; ".join(reasons) or "no compatible tag/tree-sitter-version pairing found"
-    return VersionResolution(None, None, error=detail)
+    return VersionErr(detail)
 
 
 def language_ts_version(root: Path, lang: LangAndWrapper) -> str | None:
@@ -526,7 +592,7 @@ def language_ts_version(root: Path, lang: LangAndWrapper) -> str | None:
     return None
 
 
-def resolve_target(root: Path, lang: LangAndWrapper, tree_sitter_versions: list[str], *, deep: bool = True) -> Target:
+def resolve_target(root: Path, lang: LangAndWrapper, tree_sitter_versions: list[Version], *, deep: bool = True) -> Target:
     """Resolve a `Target` for `lang` without mutating anything.
 
     `deep=True` (default -- the real propose flow) resolves both tag and
@@ -552,11 +618,12 @@ def resolve_target(root: Path, lang: LangAndWrapper, tree_sitter_versions: list[
             resolution = resolve_tag_and_version(
                 root, submodule, url, tree_sitter_versions, old_sha, lang
             )
-            tag, ts_version, resolution_note = (
-                resolution.tag, resolution.ts_version, resolution.note,
-            )
-            if resolution.error:
+            if isinstance(resolution, VersionErr):
                 skip_reason = resolution.error
+            else:
+                tag, ts_version, resolution_note = (
+                    resolution.tag, resolution.ts_version, resolution.note,
+                )
         else:
             tag = latest_stable_tag(url)
             ts_version = current_ts_version
@@ -1369,9 +1436,10 @@ def main() -> int:
     if not args.language:
         ug.die("a language is required (or use --list-languages).")
 
+    # Parse once here; _pick_ts_version compares these directly.
     tree_sitter_versions = sorted(
-        ug.discover_version_files(root, "languages").keys(),
-        key=version_key, reverse=True,
+        (Version(v) for v in ug.discover_version_files(root, "languages")),
+        reverse=True,
     )
     if not tree_sitter_versions:
         ug.die("no supported tree-sitter versions found in lang/languages-* files")

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -51,8 +51,6 @@ from importlib.util import module_from_spec, spec_from_loader
 from pathlib import Path
 from typing import Any
 
-from packaging.version import Version
-
 ###############################################################################
 # update-grammar import #
 ###############################################################################
@@ -209,13 +207,29 @@ def run_quiet(cmd: list[str], cwd: Path) -> None:
         raise subprocess.CalledProcessError(r.returncode, cmd, r.stdout)
 
 
-def version_key(tag: str) -> tuple[int, ...]:
-    """Sort key for a stable tag: the numeric components as an int tuple.
+@dataclass(frozen=True, order=True, init=False)
+class Version:
+    """Comparable dotted version (optional leading ``v``).
 
-    `v0.25.0` -> (0, 25, 0). Used to pick the highest tag. Assumes the
-    caller already filtered to `_STABLE_TAG_RE`-matching tags.
+    Enough for tree-sitter pins and stable release tags — not a PEP 440
+    implementation. ``Version.parse("v0.25.0")`` compares equal to
+    ``Version.parse("0.25.0")``; ``str`` always drops a leading ``v``.
     """
-    return tuple(int(part) for part in tag.lstrip("vV").split("."))
+    parts: tuple[int, ...]
+
+    def __init__(self, parts: tuple[int, ...]) -> None:
+        object.__setattr__(self, "parts", parts)
+
+    @classmethod
+    def parse(cls, text: str) -> Version:
+        """Parse a dotted version string (optional leading ``v``)."""
+        return cls(tuple(int(part) for part in text.lstrip("vV").split(".")))
+
+    def __str__(self) -> str:
+        return ".".join(map(str, self.parts))
+
+    def __repr__(self) -> str:
+        return f"Version.parse({str(self)!r})"
 
 
 def gitmodules_url(root: Path, submodule: Path) -> str | None:
@@ -254,7 +268,7 @@ def gitmodules_url(root: Path, submodule: Path) -> str | None:
 MAX_TAGS_EXAMINED = 4
 
 # tree-sitter >= 0.24 is known to break C++ external scanners (scanner.cc).
-_CPP_SCANNER_CEILING = Version("0.24.0")
+_CPP_SCANNER_CEILING = Version.parse("0.24.0")
 _CPP_SCANNER_CEILING_STR = str(_CPP_SCANNER_CEILING)
 
 # ABI 15's only grammar-authoring feature that can't be expressed in ABI 14
@@ -363,7 +377,7 @@ def _list_stable_tags(url: str) -> list[str]:
     # We still need to filter here, because the above pattern
     # does not filter pre-release tags.
     stable = [t for t in tags if _STABLE_TAG_RE.match(t)]
-    return sorted(stable, key=version_key, reverse=True)
+    return sorted(stable, key=Version.parse, reverse=True)
 
 
 def latest_stable_tag(url: str) -> str | None:
@@ -510,7 +524,7 @@ def _evaluate_tag(
     upstream_cpp = _upstream_has_cpp_scanner(fetched, tag)
     has_cpp = upstream_cpp or semgrep_cpp
     floor_str = _declared_min_ts_version(fetched, tag)
-    floor = Version(floor_str) if floor_str else None
+    floor = Version.parse(floor_str) if floor_str else None
     # Only a stale semgrep .cc can force < 0.24 while upstream declares
     # >= 0.24 (upstream cannot ship .cc at that floor). Ignore the floor
     # so we can still propose under the C++ ceiling.
@@ -1438,7 +1452,7 @@ def main() -> int:
 
     # Parse once here; _pick_ts_version compares these directly.
     tree_sitter_versions = sorted(
-        (Version(v) for v in ug.discover_version_files(root, "languages")),
+        (Version.parse(v) for v in ug.discover_version_files(root, "languages")),
         reverse=True,
     )
     if not tree_sitter_versions:

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -9,6 +9,7 @@ by the integration run in the workflow.
 
 from __future__ import annotations
 
+import contextlib
 import sys
 import unittest
 import unittest.mock
@@ -138,15 +139,23 @@ class TestLanguageTsVersion(unittest.TestCase):
                 "0.20.6": ["java", "ruby"],
                 "0.26.3": ["python", "php"],
             })
-            self.assertEqual(pg.language_ts_version(root, "python"), "0.26.3")
-            self.assertEqual(pg.language_ts_version(root, "java"), "0.20.6")
+            self.assertEqual(
+                pg.language_ts_version(root, pg.LangAndWrapper("python", "python")),
+                "0.26.3",
+            )
+            self.assertEqual(
+                pg.language_ts_version(root, pg.LangAndWrapper("java", "java")),
+                "0.20.6",
+            )
 
     def test_absent_returns_none(self):
         with TemporaryDirectory() as d:
             root = Path(d)
             self._repo_with_versions(root, {"0.26.3": ["python"]})
             # gomod is in no languages-* file.
-            self.assertIsNone(pg.language_ts_version(root, "go-mod"))
+            self.assertIsNone(
+                pg.language_ts_version(root, pg.LangAndWrapper("gomod", "go-mod"))
+            )
 
 
 ###############################################################################
@@ -157,7 +166,8 @@ class TestLanguageTsVersion(unittest.TestCase):
 class TestPrShaping(unittest.TestCase):
     def test_branch_name_is_tag_keyed(self):
         self.assertEqual(
-            pg.branch_name("python", "v0.25.0"), "grammar-update/python/v0.25.0"
+            pg.branch_name(pg.LangAndWrapper("python", "python"), "v0.25.0"),
+            "grammar-update/python/v0.25.0",
         )
 
     def test_compare_url_strips_dot_git(self):
@@ -199,18 +209,22 @@ class TestReleaseDialects(unittest.TestCase):
         with unittest.mock.patch.object(
             pg, "downstream_repo_exists", lambda d: d != "php-only"
         ):
-            self.assertEqual(pg.release_dialects("php", "php"), ["php"])
+            self.assertEqual(
+                pg.release_dialects(pg.LangAndWrapper("php", "php")), ["php"]
+            )
 
     def test_keeps_all_when_all_exist(self):
         with unittest.mock.patch.object(pg, "downstream_repo_exists", lambda _d: True):
             self.assertEqual(
-                pg.release_dialects("typescript", "typescript"),
+                pg.release_dialects(pg.LangAndWrapper("typescript", "typescript")),
                 ["typescript", "tsx"],
             )
 
     def test_falls_back_to_language_when_none_exist(self):
         with unittest.mock.patch.object(pg, "downstream_repo_exists", lambda _d: False):
-            self.assertEqual(pg.release_dialects("php", "php"), ["php"])
+            self.assertEqual(
+                pg.release_dialects(pg.LangAndWrapper("php", "php")), ["php"]
+            )
 
 
 class TestProposeFailurePath(unittest.TestCase):
@@ -221,7 +235,7 @@ class TestProposeFailurePath(unittest.TestCase):
     """
 
     TARGET = pg.Target(
-        language="php", wrapper="php", submodule=Path("/tmp/sub"),
+        lang=pg.LangAndWrapper(language="php", wrapper="php"), submodule=Path("/tmp/sub"),
         ts_version="0.26.3", url="https://x/y.git", tag="v0.24.2",
     )
 
@@ -340,13 +354,15 @@ class TestResultArtifact(unittest.TestCase):
 class TestUpToDateFilter(unittest.TestCase):
     """The cheap pre-filter that keeps up-to-date languages out of the build."""
 
+    LANG = pg.LangAndWrapper(language="php", wrapper="php")
+
     def _patch(self, recorded, tag_sha, tag="v1.0.0", url="https://x/y.git"):
         # is_up_to_date compares recorded gitlink SHA vs the tag's commit SHA.
         return (
             unittest.mock.patch.object(
                 pg, "resolve_target",
-                lambda root, lang: pg.Target(
-                    language=lang, wrapper=lang, submodule=Path("/tmp/sub"),
+                lambda root, lang, tree_sitter_versions=None, deep=True: pg.Target(
+                    lang=lang, submodule=Path("/tmp/sub"),
                     ts_version="0.26.3", url=url, tag=tag,
                 ),
             ),
@@ -357,27 +373,29 @@ class TestUpToDateFilter(unittest.TestCase):
     def test_up_to_date_when_shas_match(self):
         p1, p2, p3 = self._patch(recorded="abc123", tag_sha="abc123")
         with p1, p2, p3:
-            self.assertIs(pg.is_up_to_date(Path("."), "php"), True)
+            self.assertIs(pg.is_up_to_date(Path("."), self.LANG), True)
 
     def test_behind_when_shas_differ(self):
         p1, p2, p3 = self._patch(recorded="abc123", tag_sha="def456")
         with p1, p2, p3:
-            self.assertIs(pg.is_up_to_date(Path("."), "php"), False)
+            self.assertIs(pg.is_up_to_date(Path("."), self.LANG), False)
 
     def test_none_when_no_tag(self):
         with unittest.mock.patch.object(
             pg, "resolve_target",
-            lambda root, lang: pg.Target(
-                language=lang, wrapper=lang, submodule=Path("/tmp/s"),
+            lambda root, lang, tree_sitter_versions=None, deep=True: pg.Target(
+                lang=lang, submodule=Path("/tmp/s"),
                 url="u", tag=None,
             ),
         ):
-            self.assertIsNone(pg.is_up_to_date(Path("."), "php"))
+            self.assertIsNone(pg.is_up_to_date(Path("."), self.LANG))
 
 
 class TestReviewAgent(unittest.TestCase):
     def test_prompt_drives_fix_semgrep_grammar_skill(self):
-        p = pg.review_agent_prompt("php", "php", "v0.24.2", "FAIL log here")
+        p = pg.review_agent_prompt(
+            pg.LangAndWrapper("php", "php"), "v0.24.2", "FAIL log here"
+        )
         # Must invoke Marc-André's skill (not hand-rolled fix logic), pass the
         # language/tag, forbid committing, and surface the failing log.
         self.assertIn("fix-semgrep-grammar", p)
@@ -446,7 +464,7 @@ class TestTagCommitSha(unittest.TestCase):
 class TestExistingProposal(unittest.TestCase):
     """The cheap pre-build check for an already-proposed lang+tag."""
 
-    TARGET = pg.Target(language="php", wrapper="php", submodule=Path("/tmp/s"),
+    TARGET = pg.Target(pg.LangAndWrapper(language="php", wrapper="php"), submodule=Path("/tmp/s"),
                        ts_version="0.26.3", tag="v0.24.2")
 
     def test_existing_branch_short_circuits(self):
@@ -500,6 +518,322 @@ class TestTail(unittest.TestCase):
 
     def test_shorter_than_n_is_whole(self):
         self.assertEqual(pg.tail("a\nb", 10), "a\nb")
+
+
+###############################################################################
+# Smart tag+version resolution #
+###############################################################################
+
+
+class TestListStableTags(unittest.TestCase):
+    def test_sorted_newest_first(self):
+        import subprocess as sp
+        out = "a\trefs/tags/v0.20.0\nb\trefs/tags/v0.25.0\nc\trefs/tags/v0.9.0\n"
+        with unittest.mock.patch.object(
+            pg, "git_query", lambda cmd, cwd: sp.CompletedProcess(cmd, 0, out, "")
+        ):
+            self.assertEqual(pg._list_stable_tags("u"), ["v0.25.0", "v0.20.0", "v0.9.0"])
+
+    def test_passes_patterns_to_ls_remote(self):
+        import subprocess as sp
+        seen = []
+
+        def capture(cmd, cwd):
+            seen.append(cmd)
+            return sp.CompletedProcess(cmd, 0, "", "")
+
+        with unittest.mock.patch.object(pg, "git_query", capture):
+            pg._list_stable_tags("u")
+        self.assertEqual(seen[0][:4], ["git", "ls-remote", "--tags", "--refs"])
+        self.assertIn("refs/tags/v[0-9]*", seen[0])
+        self.assertIn("refs/tags/[0-9]*", seen[0])
+
+    def test_empty_on_failure(self):
+        import subprocess as sp
+        with unittest.mock.patch.object(
+            pg, "git_query", lambda cmd, cwd: sp.CompletedProcess(cmd, 1, "", "")
+        ):
+            self.assertEqual(pg._list_stable_tags("u"), [])
+
+    def test_latest_stable_tag_still_works(self):
+        with unittest.mock.patch.object(
+            pg, "_list_stable_tags", lambda url: ["v0.25.0", "v0.20.0"]
+        ):
+            self.assertEqual(pg.latest_stable_tag("u"), "v0.25.0")
+        with unittest.mock.patch.object(pg, "_list_stable_tags", lambda url: []):
+            self.assertIsNone(pg.latest_stable_tag("u"))
+
+    def test_list_newer_stable_tags_filters_and_stops(self):
+        fetched = pg.FetchedSubmodule(Path("/tmp/s"))
+        with unittest.mock.patch.object(
+            pg, "_list_stable_tags",
+            lambda url: ["v0.25.0", "v0.24.0", "v0.20.0"],
+        ), unittest.mock.patch.object(
+            pg.FetchedSubmodule, "is_newer_than",
+            lambda self, tag, old_sha: tag not in ("v0.24.0", "v0.20.0"),
+        ):
+            self.assertEqual(
+                fetched.list_newer_stable_tags("u", "OLD"),
+                ["v0.25.0"],
+            )
+
+    def test_list_newer_stable_tags_none_when_empty(self):
+        fetched = pg.FetchedSubmodule(Path("/tmp/s"))
+        with unittest.mock.patch.object(pg, "_list_stable_tags", lambda url: []):
+            self.assertIsNone(fetched.list_newer_stable_tags("u", "OLD"))
+
+
+class TestRequiresAbi15(unittest.TestCase):
+    def _fetched(self):
+        return pg.FetchedSubmodule(Path("/tmp/s"))
+
+    def test_detects_top_level_reserved_field(self):
+        text = 'module.exports = grammar({\n  name: "x",\n  reserved: {\n    global: $ => [],\n  },\n});\n'
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: text
+        ):
+            self.assertTrue(pg._requires_abi15(self._fetched(), "v1.0.0"))
+
+    def test_false_when_absent(self):
+        text = 'module.exports = grammar({\n  name: "x",\n  rules: {},\n});\n'
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: text
+        ):
+            self.assertFalse(pg._requires_abi15(self._fetched(), "v1.0.0"))
+
+    def test_false_when_file_absent(self):
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: None
+        ):
+            self.assertFalse(pg._requires_abi15(self._fetched(), "v1.0.0"))
+
+
+class TestDeclaredMinTsVersion(unittest.TestCase):
+    def _fetched(self):
+        return pg.FetchedSubmodule(Path("/tmp/s"))
+
+    def test_extracts_from_dev_dependencies(self):
+        text = '{"devDependencies": {"tree-sitter-cli": "^0.25.3"}}'
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: text
+        ):
+            self.assertEqual(pg._declared_min_ts_version(self._fetched(), "v1"), "0.25.3")
+
+    def test_extracts_from_peer_dependencies(self):
+        text = '{"peerDependencies": {"tree-sitter-cli": "~0.24.0"}}'
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: text
+        ):
+            self.assertEqual(pg._declared_min_ts_version(self._fetched(), "v1"), "0.24.0")
+
+    def test_none_when_absent(self):
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: '{"name": "x"}'
+        ):
+            self.assertIsNone(pg._declared_min_ts_version(self._fetched(), "v1"))
+
+    def test_none_when_file_missing(self):
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: None
+        ):
+            self.assertIsNone(pg._declared_min_ts_version(self._fetched(), "v1"))
+
+    def test_none_on_invalid_json(self):
+        with unittest.mock.patch.object(
+            pg.FetchedSubmodule, "read_tag_file", lambda self, t, p: "not json"
+        ):
+            self.assertIsNone(pg._declared_min_ts_version(self._fetched(), "v1"))
+
+
+class TestResolveTagAndVersion(unittest.TestCase):
+    """Orchestration tests: mock every git-touching helper, verify the
+    newer-than-current / tag-walk-back / version-capping / floor logic."""
+
+    OLD_SHA = "OLDSHA"
+    LANG = pg.LangAndWrapper(language="ruby", wrapper="ruby")
+    VERSIONS = ["0.26.3", "0.22.6", "0.20.8"]  # newest-first, as main() sorts
+
+    @contextlib.contextmanager
+    def _patch(self, tags, reserved_tags=(), cpp_scanner_tags=(), floors=None,
+              fetch_ok=True, semgrep_cpp=False):
+        floors = floors or {}
+
+        def fake_fetch(submodule):
+            if not fetch_ok:
+                return None
+            fetched = unittest.mock.MagicMock(spec=pg.FetchedSubmodule)
+            fetched.path = submodule
+            fetched.list_newer_stable_tags.side_effect = (
+                lambda url, old_sha: None if tags is None else list(tags)
+            )
+            return fetched
+
+        with unittest.mock.patch.multiple(
+            pg,
+            _requires_abi15=lambda sub, tag: tag in reserved_tags,
+            _upstream_has_cpp_scanner=lambda sub, tag: tag in cpp_scanner_tags,
+            _semgrep_has_cpp_scanner=lambda root, lang: semgrep_cpp,
+            _declared_min_ts_version=lambda sub, tag: floors.get(tag),
+        ), unittest.mock.patch.object(pg.FetchedSubmodule, "fetch", fake_fetch):
+            yield
+
+    def _resolve(self, **kwargs):
+        versions = kwargs.pop("versions", self.VERSIONS)
+        with self._patch(**kwargs):
+            return pg.resolve_tag_and_version(
+                Path("."), Path("/tmp/s"), "u", versions, self.OLD_SHA, self.LANG,
+            )
+
+    def test_picks_latest_tag_and_highest_version(self):
+        r = self._resolve(tags=["v0.26.0", "v0.25.0"])
+        self.assertEqual(r.tag, "v0.26.0")
+        self.assertEqual(r.ts_version, "0.26.3")
+        self.assertIsNone(r.error)
+
+    def test_abi15_tag_falls_back_to_older_tag(self):
+        r = self._resolve(tags=["v0.26.0", "v0.25.0"], reserved_tags=["v0.26.0"])
+        self.assertEqual(r.tag, "v0.25.0")
+        self.assertIsNone(r.error)
+
+    def test_all_tags_require_abi15_is_an_error(self):
+        r = self._resolve(tags=["v0.26.0", "v0.25.0"],
+                          reserved_tags=["v0.26.0", "v0.25.0"])
+        self.assertIsNone(r.tag)
+        self.assertIn("ABI 15", r.error)
+
+    def test_cpp_scanner_caps_below_0_24(self):
+        r = self._resolve(tags=["v1.0.0"], cpp_scanner_tags=["v1.0.0"])
+        self.assertEqual(r.ts_version, "0.22.6")
+        self.assertIn("scanner.cc", r.note)
+        self.assertIn("upstream", r.note)
+
+    def test_semgrep_only_cpp_scanner_caps_and_reports(self):
+        # Upstream has no scanner.cc, but semgrep-<wrapper> still does --
+        # same cap, and the note must call out the stale extension fork.
+        r = self._resolve(tags=["v1.0.0"], semgrep_cpp=True)
+        self.assertEqual(r.ts_version, "0.22.6")
+        self.assertIn("semgrep-ruby/src/scanner.cc", r.note)
+        self.assertIn("still C++", r.note)
+        self.assertIn("upstream", r.note)
+
+    def test_cpp_ceiling_wins_over_conflicting_floor(self):
+        # Floor >= 0.24 is incompatible with a C++ scanner; keep the newest
+        # tag and the < 0.24 pin, and mention the conflict.
+        r = self._resolve(
+            tags=["v0.23.1"], semgrep_cpp=True, floors={"v0.23.1": "0.24.4"},
+        )
+        self.assertEqual(r.tag, "v0.23.1")
+        self.assertEqual(r.ts_version, "0.22.6")
+        self.assertIn("0.24.4", r.note)
+        self.assertIn("conflicts", r.note)
+
+    def test_unmet_floor_is_an_error(self):
+        r = self._resolve(tags=["v1.0.0"], floors={"v1.0.0": "0.30.0"})
+        self.assertIsNone(r.tag)
+        self.assertIn("0.30.0", r.error)
+
+    def test_no_tags_upstream_is_an_error(self):
+        r = self._resolve(tags=None)
+        self.assertIn("no stable release tag", r.error)
+
+    def test_stops_at_first_tag_not_newer_than_current(self):
+        # list_newer_stable_tags already filtered out v0.24.0 and older; only
+        # the ABI-15 v0.25.0 remains as a candidate.
+        r = self._resolve(tags=["v0.25.0"], reserved_tags=["v0.25.0"])
+        self.assertIsNone(r.tag)
+        self.assertIn("ABI 15", r.error)
+
+    def test_no_newer_tag_is_a_distinct_error(self):
+        r = self._resolve(tags=[])
+        self.assertIsNone(r.tag)
+        self.assertIn("already at", r.error)
+
+    def test_examines_at_most_max_tags(self):
+        many_tags = [f"v0.{i}.0" for i in range(30, 0, -1)]  # 30 tags, all bad
+        examined = []
+
+        def counting_abi15(sub, tag):
+            examined.append(tag)
+            return True
+
+        with self._patch(tags=many_tags, reserved_tags=many_tags), \
+             unittest.mock.patch.object(pg, "_requires_abi15", counting_abi15):
+            r = pg.resolve_tag_and_version(
+                Path("."), Path("/tmp/s"), "u", self.VERSIONS, self.OLD_SHA, self.LANG,
+            )
+        self.assertEqual(len(examined), pg.MAX_TAGS_EXAMINED)
+        self.assertEqual(examined, many_tags[: pg.MAX_TAGS_EXAMINED])
+        self.assertIsNone(r.tag)
+
+
+class TestFetchTagsPreservesAncestry(unittest.TestCase):
+    """Regression test with a REAL git repo (no mocks): FetchedSubmodule.fetch
+    must not re-shallow the submodule, or is_newer_than's merge-base check
+    silently breaks for any tag more than one commit past old_sha -- i.e.
+    almost every real bump. A mocked test can't catch this class of bug."""
+
+    def _git(self, cwd, *args):
+        import subprocess
+        return subprocess.run(["git", *args], cwd=cwd, check=True,
+                              capture_output=True, text=True).stdout.strip()
+
+    def test_ancestry_survives_fetch_tags_after_unshallow(self):
+        import subprocess
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            upstream = root / "upstream"
+            upstream.mkdir()
+            self._git(upstream, "init", "-q")
+            self._git(upstream, "config", "user.email", "t@t.com")
+            self._git(upstream, "config", "user.name", "t")
+            old_sha = None
+            for i in range(3):
+                (upstream / "f.txt").write_text(str(i))
+                self._git(upstream, "add", "-A")
+                self._git(upstream, "commit", "-q", "-m", f"c{i}")
+                self._git(upstream, "tag", f"v1.{i}.0")
+                if i == 0:
+                    old_sha = self._git(upstream, "rev-parse", "HEAD")
+
+            submodule = root / "sub"
+            # --no-local: a plain local-path clone silently ignores --depth
+            # (git hardlinks the whole object store), so this is needed to
+            # get a genuinely shallow clone -- matching what CI's network
+            # clone of the real submodule produces.
+            subprocess.run(
+                ["git", "clone", "-q", "--no-local", "--depth", "1", "--branch", "v1.0.0",
+                 str(upstream), str(submodule)],
+                check=True, capture_output=True,
+            )
+            self.assertTrue(pg.ug.is_shallow_repo(submodule))
+            subprocess.run(["git", "fetch", "-q", "origin", "--unshallow"],
+                           cwd=submodule, check=True, capture_output=True)
+
+            fetched = pg.FetchedSubmodule.fetch(submodule)
+            self.assertIsNotNone(fetched)
+            self.assertTrue(
+                fetched.is_newer_than("v1.2.0", old_sha),
+                "merge-base ancestry check failed -- FetchedSubmodule.fetch "
+                "likely re-shallowed the submodule",
+            )
+
+
+class TestResolveTargetDeepFlag(unittest.TestCase):
+    def test_is_up_to_date_uses_shallow_resolution(self):
+        calls = []
+        lang = pg.LangAndWrapper(language="php", wrapper="php")
+
+        def fake_resolve(root, lang, tree_sitter_versions=None, deep=True):
+            calls.append(deep)
+            return pg.Target(
+                lang=lang, submodule=Path("/tmp/s"),
+                ts_version="0.26.3", url="u", tag="v1.0.0",
+            )
+        with unittest.mock.patch.object(pg, "resolve_target", fake_resolve), \
+             unittest.mock.patch.object(pg, "recorded_submodule_sha", lambda r, s: "x"), \
+             unittest.mock.patch.object(pg, "tag_commit_sha", lambda u, t: "x"):
+            pg.is_up_to_date(Path("."), lang)
+        self.assertEqual(calls, [False])
 
 
 if __name__ == "__main__":

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -18,8 +18,6 @@ from importlib.util import module_from_spec, spec_from_loader
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
-from packaging.version import Version
-
 SCRIPT_PATH = Path(__file__).resolve().parent / "propose-grammar-update"
 
 
@@ -54,18 +52,19 @@ class TestStableTagFilter(unittest.TestCase):
             self.assertNotRegex(tag, pg._STABLE_TAG_RE)
 
 
-class TestVersionKey(unittest.TestCase):
-    def test_v_prefix_stripped_and_numeric(self):
-        self.assertEqual(pg.version_key("v0.25.0"), (0, 25, 0))
-        self.assertEqual(pg.version_key("2.3"), (2, 3))
+class TestVersion(unittest.TestCase):
+    def test_v_prefix_stripped(self):
+        self.assertEqual(pg.Version.parse("v0.25.0"), pg.Version.parse("0.25.0"))
+        self.assertEqual(str(pg.Version.parse("v0.25.0")), "0.25.0")
+        self.assertEqual(pg.Version.parse("2.3").parts, (2, 3))
 
     def test_orders_correctly(self):
         # The classic sort -V trap: 0.25.0 must beat 0.5.0.
         tags = ["v0.5.0", "v0.25.0", "v0.9.0", "v0.10.0"]
-        self.assertEqual(max(tags, key=pg.version_key), "v0.25.0")
+        self.assertEqual(max(tags, key=pg.Version.parse), "v0.25.0")
 
     def test_bare_and_v_mix(self):
-        self.assertEqual(max(["1.2.13", "v1.10.0"], key=pg.version_key), "v1.10.0")
+        self.assertEqual(max(["1.2.13", "v1.10.0"], key=pg.Version.parse), "v1.10.0")
 
 
 ###############################################################################
@@ -587,12 +586,12 @@ class TestListStableTags(unittest.TestCase):
 
 
 class TestPickTsVersion(unittest.TestCase):
-    VERSIONS = [Version("0.26.3"), Version("0.22.6"), Version("0.20.8")]
+    VERSIONS = [pg.Version.parse("0.26.3"), pg.Version.parse("0.22.6"), pg.Version.parse("0.20.8")]
 
     def test_no_constraints_picks_newest(self):
         self.assertEqual(
             pg._pick_ts_version(self.VERSIONS, floor=None, ceiling=None),
-            Version("0.26.3"),
+            pg.Version.parse("0.26.3"),
         )
 
     def test_cpp_caps_below_0_24(self):
@@ -600,15 +599,15 @@ class TestPickTsVersion(unittest.TestCase):
             pg._pick_ts_version(
                 self.VERSIONS, floor=None, ceiling=pg._CPP_SCANNER_CEILING,
             ),
-            Version("0.22.6"),
+            pg.Version.parse("0.22.6"),
         )
 
     def test_floor_filters_low_versions(self):
         self.assertEqual(
             pg._pick_ts_version(
-                self.VERSIONS, floor=Version("0.22.0"), ceiling=None,
+                self.VERSIONS, floor=pg.Version.parse("0.22.0"), ceiling=None,
             ),
-            Version("0.26.3"),
+            pg.Version.parse("0.26.3"),
         )
 
     def test_pick_none_when_floor_conflicts_with_cpp(self):
@@ -616,14 +615,14 @@ class TestPickTsVersion(unittest.TestCase):
         # the semgrep-only-C++ case before calling.
         self.assertIsNone(pg._pick_ts_version(
             self.VERSIONS,
-            floor=Version("0.24.4"),
+            floor=pg.Version.parse("0.24.4"),
             ceiling=pg._CPP_SCANNER_CEILING,
         ))
 
     def test_pick_none_when_unmet_floor(self):
         self.assertIsNone(
             pg._pick_ts_version(
-                self.VERSIONS, floor=Version("0.30.0"), ceiling=None,
+                self.VERSIONS, floor=pg.Version.parse("0.30.0"), ceiling=None,
             )
         )
 
@@ -633,14 +632,14 @@ class TestVersionNote(unittest.TestCase):
 
     def test_none_without_cpp(self):
         self.assertIsNone(pg._version_note(
-            self.LANG, "v1", Version("0.26.3"),
+            self.LANG, "v1", pg.Version.parse("0.26.3"),
             upstream_cpp=False, semgrep_cpp=False,
             floor=None,
         ))
 
     def test_semgrep_only_cpp(self):
         note = pg._version_note(
-            self.LANG, "v1", Version("0.22.6"),
+            self.LANG, "v1", pg.Version.parse("0.22.6"),
             upstream_cpp=False, semgrep_cpp=True,
             floor=None,
         )
@@ -649,18 +648,18 @@ class TestVersionNote(unittest.TestCase):
 
     def test_floor_conflict_appended_when_chosen_below_floor(self):
         note = pg._version_note(
-            self.LANG, "v1", Version("0.22.6"),
+            self.LANG, "v1", pg.Version.parse("0.22.6"),
             upstream_cpp=False, semgrep_cpp=True,
-            floor=Version("0.24.4"),
+            floor=pg.Version.parse("0.24.4"),
         )
         self.assertIn("0.24.4", note)
         self.assertIn("conflicts", note)
 
     def test_compatible_floor_not_mentioned(self):
         note = pg._version_note(
-            self.LANG, "v1", Version("0.22.6"),
+            self.LANG, "v1", pg.Version.parse("0.22.6"),
             upstream_cpp=False, semgrep_cpp=True,
-            floor=Version("0.20.0"),
+            floor=pg.Version.parse("0.20.0"),
         )
         self.assertNotIn("conflicts", note)
         self.assertNotIn("0.20.0", note)
@@ -734,7 +733,7 @@ class TestResolveTagAndVersion(unittest.TestCase):
 
     OLD_SHA = "OLDSHA"
     LANG = pg.LangAndWrapper(language="ruby", wrapper="ruby")
-    VERSIONS = [Version("0.26.3"), Version("0.22.6"), Version("0.20.8")]  # newest-first, as main() sorts
+    VERSIONS = [pg.Version.parse("0.26.3"), pg.Version.parse("0.22.6"), pg.Version.parse("0.20.8")]  # newest-first, as main() sorts
 
     @contextlib.contextmanager
     def _patch(self, tags, reserved_tags=(), cpp_scanner_tags=(), floors=None,

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -18,6 +18,8 @@ from importlib.util import module_from_spec, spec_from_loader
 from pathlib import Path
 from tempfile import TemporaryDirectory
 
+from packaging.version import Version
+
 SCRIPT_PATH = Path(__file__).resolve().parent / "propose-grammar-update"
 
 
@@ -572,15 +574,96 @@ class TestListStableTags(unittest.TestCase):
             pg.FetchedSubmodule, "is_newer_than",
             lambda self, tag, old_sha: tag not in ("v0.24.0", "v0.20.0"),
         ):
-            self.assertEqual(
-                fetched.list_newer_stable_tags("u", "OLD"),
-                ["v0.25.0"],
-            )
+            result = fetched.list_newer_stable_tags("u", "OLD")
+            self.assertIsInstance(result, pg.NewerStableTags)
+            self.assertEqual(result.tags, ["v0.25.0"])
 
-    def test_list_newer_stable_tags_none_when_empty(self):
+    def test_list_newer_stable_tags_no_stable_tags(self):
         fetched = pg.FetchedSubmodule(Path("/tmp/s"))
         with unittest.mock.patch.object(pg, "_list_stable_tags", lambda url: []):
-            self.assertIsNone(fetched.list_newer_stable_tags("u", "OLD"))
+            self.assertIsInstance(
+                fetched.list_newer_stable_tags("u", "OLD"), pg.NoStableTags,
+            )
+
+
+class TestPickTsVersion(unittest.TestCase):
+    VERSIONS = [Version("0.26.3"), Version("0.22.6"), Version("0.20.8")]
+
+    def test_no_constraints_picks_newest(self):
+        self.assertEqual(
+            pg._pick_ts_version(self.VERSIONS, floor=None, ceiling=None),
+            Version("0.26.3"),
+        )
+
+    def test_cpp_caps_below_0_24(self):
+        self.assertEqual(
+            pg._pick_ts_version(
+                self.VERSIONS, floor=None, ceiling=pg._CPP_SCANNER_CEILING,
+            ),
+            Version("0.22.6"),
+        )
+
+    def test_floor_filters_low_versions(self):
+        self.assertEqual(
+            pg._pick_ts_version(
+                self.VERSIONS, floor=Version("0.22.0"), ceiling=None,
+            ),
+            Version("0.26.3"),
+        )
+
+    def test_pick_none_when_floor_conflicts_with_cpp(self):
+        # Picker itself does not relax; _evaluate_tag clears the floor for
+        # the semgrep-only-C++ case before calling.
+        self.assertIsNone(pg._pick_ts_version(
+            self.VERSIONS,
+            floor=Version("0.24.4"),
+            ceiling=pg._CPP_SCANNER_CEILING,
+        ))
+
+    def test_pick_none_when_unmet_floor(self):
+        self.assertIsNone(
+            pg._pick_ts_version(
+                self.VERSIONS, floor=Version("0.30.0"), ceiling=None,
+            )
+        )
+
+
+class TestVersionNote(unittest.TestCase):
+    LANG = pg.LangAndWrapper(language="ruby", wrapper="ruby")
+
+    def test_none_without_cpp(self):
+        self.assertIsNone(pg._version_note(
+            self.LANG, "v1", Version("0.26.3"),
+            upstream_cpp=False, semgrep_cpp=False,
+            floor=None,
+        ))
+
+    def test_semgrep_only_cpp(self):
+        note = pg._version_note(
+            self.LANG, "v1", Version("0.22.6"),
+            upstream_cpp=False, semgrep_cpp=True,
+            floor=None,
+        )
+        self.assertIn("semgrep-ruby/src/scanner.cc", note)
+        self.assertIn("still C++", note)
+
+    def test_floor_conflict_appended_when_chosen_below_floor(self):
+        note = pg._version_note(
+            self.LANG, "v1", Version("0.22.6"),
+            upstream_cpp=False, semgrep_cpp=True,
+            floor=Version("0.24.4"),
+        )
+        self.assertIn("0.24.4", note)
+        self.assertIn("conflicts", note)
+
+    def test_compatible_floor_not_mentioned(self):
+        note = pg._version_note(
+            self.LANG, "v1", Version("0.22.6"),
+            upstream_cpp=False, semgrep_cpp=True,
+            floor=Version("0.20.0"),
+        )
+        self.assertNotIn("conflicts", note)
+        self.assertNotIn("0.20.0", note)
 
 
 class TestRequiresAbi15(unittest.TestCase):
@@ -651,7 +734,7 @@ class TestResolveTagAndVersion(unittest.TestCase):
 
     OLD_SHA = "OLDSHA"
     LANG = pg.LangAndWrapper(language="ruby", wrapper="ruby")
-    VERSIONS = ["0.26.3", "0.22.6", "0.20.8"]  # newest-first, as main() sorts
+    VERSIONS = [Version("0.26.3"), Version("0.22.6"), Version("0.20.8")]  # newest-first, as main() sorts
 
     @contextlib.contextmanager
     def _patch(self, tags, reserved_tags=(), cpp_scanner_tags=(), floors=None,
@@ -663,9 +746,13 @@ class TestResolveTagAndVersion(unittest.TestCase):
                 return None
             fetched = unittest.mock.MagicMock(spec=pg.FetchedSubmodule)
             fetched.path = submodule
-            fetched.list_newer_stable_tags.side_effect = (
-                lambda url, old_sha: None if tags is None else list(tags)
-            )
+
+            def list_newer(url, old_sha):
+                if tags is None:
+                    return pg.NoStableTags()
+                return pg.NewerStableTags(list(tags))
+
+            fetched.list_newer_stable_tags.side_effect = list_newer
             return fetched
 
         with unittest.mock.patch.multiple(
@@ -686,23 +773,25 @@ class TestResolveTagAndVersion(unittest.TestCase):
 
     def test_picks_latest_tag_and_highest_version(self):
         r = self._resolve(tags=["v0.26.0", "v0.25.0"])
+        self.assertIsInstance(r, pg.VersionOk)
         self.assertEqual(r.tag, "v0.26.0")
         self.assertEqual(r.ts_version, "0.26.3")
-        self.assertIsNone(r.error)
+        self.assertIsNone(r.note)
 
     def test_abi15_tag_falls_back_to_older_tag(self):
         r = self._resolve(tags=["v0.26.0", "v0.25.0"], reserved_tags=["v0.26.0"])
+        self.assertIsInstance(r, pg.VersionOk)
         self.assertEqual(r.tag, "v0.25.0")
-        self.assertIsNone(r.error)
 
     def test_all_tags_require_abi15_is_an_error(self):
         r = self._resolve(tags=["v0.26.0", "v0.25.0"],
                           reserved_tags=["v0.26.0", "v0.25.0"])
-        self.assertIsNone(r.tag)
+        self.assertIsInstance(r, pg.VersionErr)
         self.assertIn("ABI 15", r.error)
 
     def test_cpp_scanner_caps_below_0_24(self):
         r = self._resolve(tags=["v1.0.0"], cpp_scanner_tags=["v1.0.0"])
+        self.assertIsInstance(r, pg.VersionOk)
         self.assertEqual(r.ts_version, "0.22.6")
         self.assertIn("scanner.cc", r.note)
         self.assertIn("upstream", r.note)
@@ -711,6 +800,7 @@ class TestResolveTagAndVersion(unittest.TestCase):
         # Upstream has no scanner.cc, but semgrep-<wrapper> still does --
         # same cap, and the note must call out the stale extension fork.
         r = self._resolve(tags=["v1.0.0"], semgrep_cpp=True)
+        self.assertIsInstance(r, pg.VersionOk)
         self.assertEqual(r.ts_version, "0.22.6")
         self.assertIn("semgrep-ruby/src/scanner.cc", r.note)
         self.assertIn("still C++", r.note)
@@ -722,6 +812,7 @@ class TestResolveTagAndVersion(unittest.TestCase):
         r = self._resolve(
             tags=["v0.23.1"], semgrep_cpp=True, floors={"v0.23.1": "0.24.4"},
         )
+        self.assertIsInstance(r, pg.VersionOk)
         self.assertEqual(r.tag, "v0.23.1")
         self.assertEqual(r.ts_version, "0.22.6")
         self.assertIn("0.24.4", r.note)
@@ -729,23 +820,24 @@ class TestResolveTagAndVersion(unittest.TestCase):
 
     def test_unmet_floor_is_an_error(self):
         r = self._resolve(tags=["v1.0.0"], floors={"v1.0.0": "0.30.0"})
-        self.assertIsNone(r.tag)
+        self.assertIsInstance(r, pg.VersionErr)
         self.assertIn("0.30.0", r.error)
 
     def test_no_tags_upstream_is_an_error(self):
         r = self._resolve(tags=None)
+        self.assertIsInstance(r, pg.VersionErr)
         self.assertIn("no stable release tag", r.error)
 
     def test_stops_at_first_tag_not_newer_than_current(self):
         # list_newer_stable_tags already filtered out v0.24.0 and older; only
         # the ABI-15 v0.25.0 remains as a candidate.
         r = self._resolve(tags=["v0.25.0"], reserved_tags=["v0.25.0"])
-        self.assertIsNone(r.tag)
+        self.assertIsInstance(r, pg.VersionErr)
         self.assertIn("ABI 15", r.error)
 
     def test_no_newer_tag_is_a_distinct_error(self):
         r = self._resolve(tags=[])
-        self.assertIsNone(r.tag)
+        self.assertIsInstance(r, pg.VersionErr)
         self.assertIn("already at", r.error)
 
     def test_examines_at_most_max_tags(self):
@@ -763,7 +855,7 @@ class TestResolveTagAndVersion(unittest.TestCase):
             )
         self.assertEqual(len(examined), pg.MAX_TAGS_EXAMINED)
         self.assertEqual(examined, many_tags[: pg.MAX_TAGS_EXAMINED])
-        self.assertIsNone(r.tag)
+        self.assertIsInstance(r, pg.VersionErr)
 
 
 class TestFetchTagsPreservesAncestry(unittest.TestCase):


### PR DESCRIPTION
We try to proactively update the tree-sitter version that builds our grammars, whether that's required by the update or not.

However, some grammar updates are not applicable because they require ABI 15 and ABI 15 is a stretch goal at this point.

In addition, a newer tree-sitter version may not be useable due to deprecated (and eventually removed) tree-sitter features.

This PR closes LANG-603.

### Checklist

- [x] N/A Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)