### PR TITLE
impl slack notifications with fable 5

### DIFF
--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -8,6 +8,10 @@ name: Propose grammar updates
 # separate integrate job then releases each green bump to semgrep-<lang> via
 # PR. semgrep-proprietary integration is deliberately out of scope.
 #
+# Any failed job triggers a Slack alert to #team-languages (see the `notify`
+# job; needs the SLACK_BOT_TOKEN secret). Test the alert path end-to-end with
+# the inject_failure + notify_channel inputs.
+#
 # See scripts/propose-grammar-update for the per-language logic.
 
 on:
@@ -28,6 +32,14 @@ on:
         description: "Full pipeline (build, bump, snapshot regen, test-lang) but push nothing: no PR here, integrate job skipped."
         type: boolean
         default: false
+      inject_failure:
+        description: "Test mode: force this job to fail, to exercise the Slack alert end-to-end (pair with notify_channel so the alert goes to you, not #team-languages)."
+        type: choice
+        options: [none, enumerate, propose, integrate]
+        default: none
+      notify_channel:
+        description: "Test mode: Slack channel or member ID (e.g. U0123456789 for a DM) to send the failure alert to instead of #team-languages."
+        required: false
 
 permissions:
   contents: write         # push grammar-update/* branches in THIS repo
@@ -42,6 +54,11 @@ jobs:
     outputs:
       languages: ${{ steps.list.outputs.languages }}
     steps:
+      - name: Inject failure (test mode)
+        if: inputs.inject_failure == 'enumerate'
+        run: |
+          echo "::error::Failure injected via the inject_failure input (test mode)"
+          exit 1
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
@@ -85,6 +102,11 @@ jobs:
       matrix:
         language: ${{ fromJSON(needs.enumerate.outputs.languages) }}
     steps:
+      - name: Inject failure (test mode)
+        if: inputs.inject_failure == 'propose'
+        run: |
+          echo "::error::Failure injected via the inject_failure input (test mode)"
+          exit 1
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
@@ -204,6 +226,11 @@ jobs:
       matrix:
         language: ${{ fromJSON(needs.enumerate.outputs.languages) }}
     steps:
+      - name: Inject failure (test mode)
+        if: inputs.inject_failure == 'integrate'
+        run: |
+          echo "::error::Failure injected via the inject_failure input (test mode)"
+          exit 1
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
@@ -306,3 +333,42 @@ jobs:
           merge-multiple: true
       - name: Render summary
         run: python scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
+
+  # Slack alert on any failed job (LANG-604). Job-level results are the
+  # authoritative failure signal: propose-grammar-update exits non-zero on a
+  # failed bump/test, and this also catches failures the script can't see
+  # from inside (build breakage, timeouts, crashes). The message carries only
+  # job statuses + a run link — never grammar source or logs.
+  notify:
+    name: Alert on failure
+    needs: [enumerate, propose, integrate]
+    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
+        with:
+          egress-policy: audit
+      - name: Post Slack alert
+        env:
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Test mode (notify_channel set) redirects the alert to the
+          # engineer running the test instead of paging #team-languages.
+          CHANNEL: ${{ inputs.notify_channel || '#team-languages' }}
+          TEST_MODE: ${{ inputs.notify_channel != '' || (inputs.inject_failure != '' && inputs.inject_failure != 'none') }}
+          RESULTS: "enumerate: ${{ needs.enumerate.result }}, propose: ${{ needs.propose.result }}, integrate: ${{ needs.integrate.result }}"
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+          ACTOR: ${{ github.actor }}
+          EVENT: ${{ github.event_name }}
+        run: |
+          prefix=""
+          if [ "$TEST_MODE" = "true" ]; then prefix=":test_tube: [test mode] "; fi
+          text="${prefix}:rotating_light: *Grammar update workflow failed* (${RESULTS}) — triggered by ${ACTOR} via ${EVENT}. <${RUN_URL}|View run>"
+          payload=$(jq -n --arg channel "$CHANNEL" --arg text "$text" '{channel: $channel, text: $text}')
+          resp=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
+            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
+            -H 'Content-Type: application/json; charset=utf-8' \
+            --data "$payload")
+          # chat.postMessage returns HTTP 200 even on error; check the ok field.
+          echo "$resp" | jq -e '.ok' >/dev/null \
+            || { echo "::error::Slack API error: $(echo "$resp" | jq -r '.error')"; exit 1; }

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -10,8 +10,8 @@ name: Propose grammar updates
 #
 # The `notify` job (needs the SLACK_BOT_TOKEN secret) posts to
 # #team-languages: an alert when any job fails, a success note with PR links
-# when updates were proposed, silence when nothing happened. Test the alert
-# path end-to-end with the inject_failure + notify_channel inputs.
+# when updates were proposed, a "nothing to do" heartbeat otherwise. Test the
+# alert path end-to-end with the inject_failure + notify_channel inputs.
 #
 # See scripts/propose-grammar-update for the per-language logic.
 
@@ -336,8 +336,8 @@ jobs:
         run: python scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
 
   # Slack notification (LANG-604): pages #team-languages when any job fails,
-  # and posts a success note (with PR links) when update PRs were opened.
-  # Runs where nothing happened (all no-op) stay silent. Job-level results
+  # posts a success note (with PR links) when update PRs were opened, and a
+  # quiet "nothing to do" heartbeat otherwise. Job-level results
   # are the authoritative failure signal: propose-grammar-update exits
   # non-zero on a failed bump/test, and this also catches failures the
   # script can't see from inside (build breakage, timeouts, crashes). The

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -349,6 +349,22 @@ jobs:
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
+      # Checkout + artifacts only so the alert can embed the same per-language
+      # status table the summary job renders (regenerated here — the Actions
+      # API doesn't expose another job's step summary). No submodules: this
+      # job must never run upstream grammar code, it holds the Slack token.
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+      - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
+        with:
+          python-version: '3.11'
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        # A crash before any propose leg wrote its result (e.g. enumerate
+        # failed) leaves no artifacts; the alert then falls back to
+        # job statuses + run link.
+        continue-on-error: true
+        with:
+          path: results
+          merge-multiple: true
       - name: Post Slack alert
         env:
           SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
@@ -364,11 +380,20 @@ jobs:
           prefix=""
           if [ "$TEST_MODE" = "true" ]; then prefix=":test_tube: [test mode] "; fi
           text="${prefix}:rotating_light: *Grammar update workflow failed* (${RESULTS}) — triggered by ${ACTOR} via ${EVENT}. <${RUN_URL}|View run>"
+          # Append the per-language status table (same renderer as the run
+          # summary), as a code block since Slack doesn't render md tables.
+          # Row count is bounded by the language set (~47), well under
+          # Slack's 40k text limit.
+          mkdir -p results
+          if find results -name '*.json' | grep -q .; then
+            summary=$(python scripts/propose-grammar-update --summarize results || true)
+            text="${text}"$'\n```\n'"${summary}"$'\n```'
+          fi
           payload=$(jq -n --arg channel "$CHANNEL" --arg text "$text" '{channel: $channel, text: $text}')
           resp=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
             -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
             -H 'Content-Type: application/json; charset=utf-8' \
             --data "$payload")
           # chat.postMessage returns HTTP 200 even on error; check the ok field.
-          echo "$resp" | jq -e '.ok' >/dev/null \
-            || { echo "::error::Slack API error: $(echo "$resp" | jq -r '.error')"; exit 1; }
+          printf '%s\n' "$resp" | jq -e '.ok' >/dev/null \
+            || { echo "::error::Slack API error: $(printf '%s\n' "$resp" | jq -r '.error')"; exit 1; }

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -10,8 +10,8 @@ name: Propose grammar updates
 #
 # The `notify` job (needs the SLACK_BOT_TOKEN secret) posts to
 # #team-languages: an alert when any job fails, a success note with PR links
-# when updates were proposed, a "nothing to do" heartbeat otherwise. Test the
-# alert path end-to-end with the inject_failure + notify_channel inputs.
+# when updates were proposed, silence when nothing happened. Test the alert
+# path end-to-end with the inject_failure + notify_channel inputs.
 #
 # See scripts/propose-grammar-update for the per-language logic.
 
@@ -336,8 +336,8 @@ jobs:
         run: python scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
 
   # Slack notification (LANG-604): pages #team-languages when any job fails,
-  # posts a success note (with PR links) when update PRs were opened, and a
-  # quiet "nothing to do" heartbeat otherwise. Job-level results
+  # and posts a success note (with PR links) when update PRs were opened.
+  # Runs where nothing happened (all no-op) stay silent. Job-level results
   # are the authoritative failure signal: propose-grammar-update exits
   # non-zero on a failed bump/test, and this also catches failures the
   # script can't see from inside (build breakage, timeouts, crashes). The

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -8,9 +8,10 @@ name: Propose grammar updates
 # separate integrate job then releases each green bump to semgrep-<lang> via
 # PR. semgrep-proprietary integration is deliberately out of scope.
 #
-# Any failed job triggers a Slack alert to #team-languages (see the `notify`
-# job; needs the SLACK_BOT_TOKEN secret). Test the alert path end-to-end with
-# the inject_failure + notify_channel inputs.
+# The `notify` job (needs the SLACK_BOT_TOKEN secret) posts to
+# #team-languages: an alert when any job fails, a success note with PR links
+# when updates were proposed, silence when nothing happened. Test the alert
+# path end-to-end with the inject_failure + notify_channel inputs.
 #
 # See scripts/propose-grammar-update for the per-language logic.
 
@@ -38,7 +39,7 @@ on:
         options: [none, enumerate, propose, integrate]
         default: none
       notify_channel:
-        description: "Test mode: Slack channel or member ID (e.g. U0123456789 for a DM) to send the failure alert to instead of #team-languages."
+        description: "Test mode: Slack channel or member ID (e.g. U0123456789 for a DM) to send notifications to instead of #team-languages."
         required: false
 
 permissions:
@@ -334,15 +335,18 @@ jobs:
       - name: Render summary
         run: python scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
 
-  # Slack alert on any failed job (LANG-604). Job-level results are the
-  # authoritative failure signal: propose-grammar-update exits non-zero on a
-  # failed bump/test, and this also catches failures the script can't see
-  # from inside (build breakage, timeouts, crashes). The message carries only
-  # job statuses + a run link — never grammar source or logs.
+  # Slack notification (LANG-604): pages #team-languages when any job fails,
+  # and posts a success note (with PR links) when update PRs were opened.
+  # Runs where nothing happened (all no-op) stay silent. Job-level results
+  # are the authoritative failure signal: propose-grammar-update exits
+  # non-zero on a failed bump/test, and this also catches failures the
+  # script can't see from inside (build breakage, timeouts, crashes). The
+  # message carries only job statuses, PR links and the status table + a run
+  # link — never grammar source or logs.
   notify:
-    name: Alert on failure
+    name: Notify Slack
     needs: [enumerate, propose, integrate]
-    if: ${{ always() && contains(needs.*.result, 'failure') }}
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-latest
     timeout-minutes: 5
     steps:
@@ -365,35 +369,61 @@ jobs:
         with:
           path: results
           merge-multiple: true
-      - name: Post Slack alert
+      - name: Compose message
+        id: compose
         env:
-          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
-          # Test mode (notify_channel set) redirects the alert to the
-          # engineer running the test instead of paging #team-languages.
-          CHANNEL: ${{ inputs.notify_channel || '#team-languages' }}
           TEST_MODE: ${{ inputs.notify_channel != '' || (inputs.inject_failure != '' && inputs.inject_failure != 'none') }}
+          FAILED: ${{ contains(needs.*.result, 'failure') }}
           RESULTS: "enumerate: ${{ needs.enumerate.result }}, propose: ${{ needs.propose.result }}, integrate: ${{ needs.integrate.result }}"
           RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
           ACTOR: ${{ github.actor }}
           EVENT: ${{ github.event_name }}
         run: |
-          prefix=""
-          if [ "$TEST_MODE" = "true" ]; then prefix=":test_tube: [test mode] "; fi
-          text="${prefix}:rotating_light: *Grammar update workflow failed* (${RESULTS}) — triggered by ${ACTOR} via ${EVENT}. <${RUN_URL}|View run>"
+          mkdir -p results
+          have_results=false
+          if find results -name '*.json' | grep -q .; then have_results=true; fi
+          # PR links come from the result JSONs (pr_url is recorded by
+          # propose-grammar-update when gh creates the PR).
+          prs=""
+          if [ "$have_results" = true ]; then
+            prs=$(jq -r 'select(.status == "updated" and .pr_url != null)
+                         | "• \(.language) \(.new_tag): \(.pr_url)"' results/*.json)
+          fi
+          if [ "$FAILED" = "true" ]; then
+            # The run link is the entry point to the failed job's log.
+            text=":rotating_light: *Grammar update workflow failed* (${RESULTS}) — triggered by ${ACTOR} via ${EVENT}. <${RUN_URL}|View run and logs>"
+          elif [ -n "$prs" ]; then
+            text=":white_check_mark: *Grammar update PRs opened* — triggered by ${ACTOR} via ${EVENT}. <${RUN_URL}|View run>"
+          else
+            # Nothing failed, nothing proposed (all no-op/up to date): stay
+            # silent rather than posting a weekly "nothing happened".
+            echo "post=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          if [ -n "$prs" ]; then
+            text="${text}"$'\n'"${prs}"
+          fi
           # Append the per-language status table (same renderer as the run
           # summary), as a code block since Slack doesn't render md tables.
           # Row count is bounded by the language set (~47), well under
           # Slack's 40k text limit.
-          mkdir -p results
-          if find results -name '*.json' | grep -q .; then
+          if [ "$have_results" = true ]; then
             summary=$(python scripts/propose-grammar-update --summarize results || true)
             text="${text}"$'\n```\n'"${summary}"$'\n```'
           fi
-          payload=$(jq -n --arg channel "$CHANNEL" --arg text "$text" '{channel: $channel, text: $text}')
-          resp=$(curl -fsS -X POST https://slack.com/api/chat.postMessage \
-            -H "Authorization: Bearer ${SLACK_BOT_TOKEN}" \
-            -H 'Content-Type: application/json; charset=utf-8' \
-            --data "$payload")
-          # chat.postMessage returns HTTP 200 even on error; check the ok field.
-          printf '%s\n' "$resp" | jq -e '.ok' >/dev/null \
-            || { echo "::error::Slack API error: $(printf '%s\n' "$resp" | jq -r '.error')"; exit 1; }
+          if [ "$TEST_MODE" = "true" ]; then text=":test_tube: [test mode] ${text}"; fi
+          { echo "text<<SLACK_MSG_EOF"; printf '%s\n' "$text"; echo "SLACK_MSG_EOF"; } >> "$GITHUB_OUTPUT"
+          echo "post=true" >> "$GITHUB_OUTPUT"
+      - name: Post to Slack
+        if: steps.compose.outputs.post == 'true'
+        uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.SLACK_BOT_TOKEN }}
+          # Fail the step on a Slack API error (default is to continue).
+          errors: true
+          payload: |
+            {
+              "channel": ${{ toJSON(inputs.notify_channel || '#team-languages') }},
+              "text": ${{ toJSON(steps.compose.outputs.text) }}
+            }

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -10,8 +10,8 @@ name: Propose grammar updates
 #
 # The `notify` job (needs the SLACK_BOT_TOKEN secret) posts to
 # #team-languages: an alert when any job fails, a success note with PR links
-# when updates were proposed, silence when nothing happened. Test the alert
-# path end-to-end with the inject_failure + notify_channel inputs.
+# when updates were proposed, a "nothing to do" heartbeat otherwise. Test the
+# alert path end-to-end with the inject_failure + notify_channel inputs.
 #
 # See scripts/propose-grammar-update for the per-language logic.
 
@@ -336,8 +336,8 @@ jobs:
         run: python scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
 
   # Slack notification (LANG-604): pages #team-languages when any job fails,
-  # and posts a success note (with PR links) when update PRs were opened.
-  # Runs where nothing happened (all no-op) stay silent. Job-level results
+  # posts a success note (with PR links) when update PRs were opened, and a
+  # quiet "nothing to do" heartbeat otherwise. Job-level results
   # are the authoritative failure signal: propose-grammar-update exits
   # non-zero on a failed bump/test, and this also catches failures the
   # script can't see from inside (build breakage, timeouts, crashes). The
@@ -395,10 +395,8 @@ jobs:
           elif [ -n "$prs" ]; then
             text=":white_check_mark: *Grammar update PRs opened* — triggered by ${ACTOR} via ${EVENT}. <${RUN_URL}|View run>"
           else
-            # Nothing failed, nothing proposed (all no-op/up to date): stay
-            # silent rather than posting a weekly "nothing happened".
-            echo "post=false" >> "$GITHUB_OUTPUT"
-            exit 0
+            # Nothing failed, nothing proposed (all no-op/up to date).
+            text=":zzz: *Grammar update run: nothing to do* — no failures, no updates proposed (${RESULTS}) — triggered by ${ACTOR} via ${EVENT}. <${RUN_URL}|View run>"
           fi
           if [ -n "$prs" ]; then
             text="${text}"$'\n'"${prs}"
@@ -413,9 +411,7 @@ jobs:
           fi
           if [ "$TEST_MODE" = "true" ]; then text=":test_tube: [test mode] ${text}"; fi
           { echo "text<<SLACK_MSG_EOF"; printf '%s\n' "$text"; echo "SLACK_MSG_EOF"; } >> "$GITHUB_OUTPUT"
-          echo "post=true" >> "$GITHUB_OUTPUT"
       - name: Post to Slack
-        if: steps.compose.outputs.post == 'true'
         uses: slackapi/slack-github-action@dcb1066f776dd043e64d0e8ba94ca15cc7e1875d # v4.0.0
         with:
           method: chat.postMessage

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -127,6 +127,7 @@ class Result:
     corpus_diff: str = ""
     tests_adapted: bool = False
     branch: str | None = None
+    pr_url: str | None = None
 
     def to_json(self) -> str:
         return json.dumps({k: v for k, v in asdict(self).items() if v is not None})
@@ -575,7 +576,20 @@ def open_pr(root: Path, target: Target, result: Result,
     if result.tests_adapted:
         ensure_label(origin_repo(), AGENT_ADAPTED_LABEL)
         create += ["--label", AGENT_ADAPTED_LABEL]
-    run_quiet(create, cwd=root)
+    # Captured (not run_quiet) so the new PR's URL — gh prints it as the last
+    # stdout line — lands in the result JSON for the Slack success message.
+    # Output is still mirrored to stderr to keep stdout JSON-pure.
+    log(f"$ {' '.join(create)}  (in {root})")
+    created = subprocess.run(create, cwd=root, text=True,
+                             capture_output=True, check=False)
+    sys.stderr.write(created.stdout)
+    sys.stderr.write(created.stderr)
+    if created.returncode != 0:
+        raise subprocess.CalledProcessError(created.returncode, create,
+                                            created.stdout)
+    url = created.stdout.strip().splitlines()[-1] if created.stdout.strip() else ""
+    if url.startswith("https://"):
+        result.pr_url = url
     return result
 
 

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -564,7 +564,11 @@ def open_pr(root: Path, target: Target, result: Result,
         result.status = "dry-run"
         return result
 
-    if proposal_exists(root, branch):
+    # Remote-only re-check: propose(keep=True) has already created the local
+    # branch by now, so proposal_exists() (which also counts local branches)
+    # would always say "exists" and no PR would ever be opened.
+    if git_query(["git", "ls-remote", "--heads", "origin", branch],
+                 cwd=root).stdout.strip():
         result.status = STATUS_EXISTS
         result.detail = f"branch {branch} already exists"
         return result

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -564,11 +564,7 @@ def open_pr(root: Path, target: Target, result: Result,
         result.status = "dry-run"
         return result
 
-    # Remote-only re-check: propose(keep=True) has already created the local
-    # branch by now, so proposal_exists() (which also counts local branches)
-    # would always say "exists" and no PR would ever be opened.
-    if git_query(["git", "ls-remote", "--heads", "origin", branch],
-                 cwd=root).stdout.strip():
+    if proposal_exists(root, branch):
         result.status = STATUS_EXISTS
         result.detail = f"branch {branch} already exists"
         return result


### PR DESCRIPTION
When the grammar automation script fails, we well alert #team-languages on Slack. You could also trigger a failure, as well as redirect the notification to DM a specific user on Slack.

This is implemented at a GitHub workflows level as opposed to on a script level. This does have the advantage of working on failures beyond the scope of a script. 

### Testing
For injecting a failure while testing, consider the following commands:
```
gh workflow run "Propose grammar updates" --ref tean/lang-604-alert-on-slack-when-unable-to-update-a-grammar-v3 -f inject_failure=enumerate -f notify_channel=U08THQM5A01
```
There are two inputs here:
- `inject_failure` (`none` / `enumerate` / `propose` / `integrate`)
- `notify_channel` - a specific channel or Slack member ID

Have done some runs. Verified it works for injecting failures. Also successfully sends notifications on failures, though it sends one notification after we attempt to propose all languages but have at least one failure.

Closes LANG-604.

### Secrets
This relies on the `SLACK_BOT_TOKEN` GitHub secret. It's used to interact with the Slack app named `Grammar Automation Bot`. Ownership of app is under me (Tean) right now.

### Checklist

- [ ] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [ ] Change has no security implications (otherwise, ping the security team)
