### PR TITLE
fix: remove second local git check on grammar automation

### DIFF
--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -945,11 +945,6 @@ def open_pr(root: Path, target: Target, result: Result,
         result.status = "dry-run"
         return result
 
-    if proposal_exists(root, branch):
-        result.status = STATUS_EXISTS
-        result.detail = f"branch {branch} already exists"
-        return result
-
     run_quiet(["git", "push", "origin", branch], cwd=root)
     create = ["gh", "pr", "create", "--title", title, "--body", body,
               "--base", base, "--head", branch]

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -838,23 +838,28 @@ def branch_name(lang: LangAndWrapper, tag: str) -> str:
     return f"grammar-update/{lang.language}/{tag}"
 
 
-def proposal_exists(root: Path, branch: str) -> bool:
-    """True if a branch (local or on origin) already exists for this proposal.
+def proposal_exists_upstream(root: Path, branch: str) -> bool:
+    """True if a branch already exists upstream for this proposal.
 
     Cheap pre-check so a re-run doesn't rebuild/re-PR an in-flight update.
-    Checks origin (the durable signal) and any local branch.
+    Checks origin (the durable signal) only.
     """
     remote = git_query(
         ["git", "ls-remote", "--heads", "origin", branch], cwd=root,
     ).stdout.strip()
-    if remote:
-        return True
+    return bool(remote)
+
+def proposal_exists_locally(root: Path, branch: str) -> bool:
+    """True if a branch already exists locally for this proposal.
+
+    Cheap pre-check so a re-run doesn't rebuild/re-PR an in-flight update.
+    Checks any local branch only.
+    """
     local = git_query(
         ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
         cwd=root,
     )
     return local.returncode == 0
-
 
 def existing_proposal(root: Path, target: Target) -> Result | None:
     """Result for an already-proposed lang+tag, or None if there is none.
@@ -866,7 +871,8 @@ def existing_proposal(root: Path, target: Target) -> Result | None:
     if target.tag is None:
         return None
     branch = branch_name(target.lang, target.tag)
-    if not proposal_exists(root, branch):
+    if not proposal_exists_upstream(root, branch) and \
+            not proposal_exists_locally(root, branch):
         return None
     return Result(language=target.lang.language, ts_version=target.ts_version,
                   new_tag=target.tag, status=STATUS_EXISTS, branch=branch,
@@ -945,7 +951,7 @@ def open_pr(root: Path, target: Target, result: Result,
         result.status = "dry-run"
         return result
 
-    if proposal_exists(root, branch):
+    if proposal_exists_upstream(root, branch):
         result.status = STATUS_EXISTS
         result.detail = f"branch {branch} already exists"
         return result

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -838,28 +838,23 @@ def branch_name(lang: LangAndWrapper, tag: str) -> str:
     return f"grammar-update/{lang.language}/{tag}"
 
 
-def proposal_exists_upstream(root: Path, branch: str) -> bool:
-    """True if a branch already exists upstream for this proposal.
+def proposal_exists(root: Path, branch: str) -> bool:
+    """True if a branch (local or on origin) already exists for this proposal.
 
     Cheap pre-check so a re-run doesn't rebuild/re-PR an in-flight update.
-    Checks origin (the durable signal) only.
+    Checks origin (the durable signal) and any local branch.
     """
     remote = git_query(
         ["git", "ls-remote", "--heads", "origin", branch], cwd=root,
     ).stdout.strip()
-    return bool(remote)
-
-def proposal_exists_locally(root: Path, branch: str) -> bool:
-    """True if a branch already exists locally for this proposal.
-
-    Cheap pre-check so a re-run doesn't rebuild/re-PR an in-flight update.
-    Checks any local branch only.
-    """
+    if remote:
+        return True
     local = git_query(
         ["git", "rev-parse", "--verify", "--quiet", f"refs/heads/{branch}"],
         cwd=root,
     )
     return local.returncode == 0
+
 
 def existing_proposal(root: Path, target: Target) -> Result | None:
     """Result for an already-proposed lang+tag, or None if there is none.
@@ -871,8 +866,7 @@ def existing_proposal(root: Path, target: Target) -> Result | None:
     if target.tag is None:
         return None
     branch = branch_name(target.lang, target.tag)
-    if not proposal_exists_upstream(root, branch) and \
-            not proposal_exists_locally(root, branch):
+    if not proposal_exists(root, branch):
         return None
     return Result(language=target.lang.language, ts_version=target.ts_version,
                   new_tag=target.tag, status=STATUS_EXISTS, branch=branch,
@@ -951,7 +945,7 @@ def open_pr(root: Path, target: Target, result: Result,
         result.status = "dry-run"
         return result
 
-    if proposal_exists_upstream(root, branch):
+    if proposal_exists(root, branch):
         result.status = STATUS_EXISTS
         result.detail = f"branch {branch} already exists"
         return result

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -860,8 +860,7 @@ def existing_proposal(root: Path, target: Target) -> Result | None:
     """Result for an already-proposed lang+tag, or None if there is none.
 
     Runs before the expensive build so a re-run on an in-flight proposal
-    costs seconds, not a full bump/test cycle. open_pr() re-checks right
-    before pushing, so the small race window stays covered.
+    costs seconds, not a full bump/test cycle.
     """
     if target.tag is None:
         return None
@@ -929,7 +928,7 @@ def open_pr(root: Path, target: Target, result: Result,
 
     The validated commit already exists on `grammar-update/<lang>/<tag>`
     (created + committed by propose in keep mode) — here we only push it and
-    open the PR. Idempotent: skips if a branch already exists upstream.
+    open the PR.
     """
     lang, tag = target.lang, result.new_tag
     base = base_branch()


### PR DESCRIPTION
Basically, when running `propose-grammar-update`, we run into the following problem:
1. Script tries to propose a PR with name `grammar-update/LANG/version`
2. Script checks there is no local git branch with the same name. Aborting if so.
3. If it can proceed, it'll create a local git branch with the name.
4. Then, it tries to open the pr in `open_pr`, but repeats step #2, always leading to abortion since we created said branch in #3.

Tldr; we never open a pr for grammar automation

This fix addresses that by removing the second check for a conflicting local branch.

### Testing
Still needs to be tested, one way to go about this is to run the workflow on both this branch and the main branch, and compare.

### Checklist

- [ ] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [ ] Change has no security implications (otherwise, ping the security team)
