### PR TITLE
Use Cursor SDK for the grammar-update review agent

### DIFF
--- a/.github/actions/setup-uv/action.yml
+++ b/.github/actions/setup-uv/action.yml
@@ -1,0 +1,6 @@
+name: Install uv
+description: Install the pinned version of uv (single source of truth for the SHA).
+runs:
+  using: composite
+  steps:
+    - uses: astral-sh/setup-uv@11f9893b081a58869d3b5fccaea48c9e9e46f990 # v8.3.2

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -25,10 +25,23 @@ on:
       language:
         description: "Language to propose (a name like 'php', or 'all'/blank for every language)"
         required: false
-      run_review_agent:
+      run_language_agent:
         description: "On test-lang failure, dispatch a Cursor agent (fix-semgrep-grammar skill) to adapt the extension grammar/tests. Off = failing bumps are just reported as failed; no Cursor dispatch ever happens."
         type: boolean
         default: false
+      verbose_language_agent:
+        description: "With run_language_agent: log full event stream instead of heartbeat (noisy; debug only)."
+        type: boolean
+        default: false
+      agent_timeout:
+        description: "With run_language_agent: wall-clock cap per language, e.g. '25m', '90s', '1h'. Blank = 25m."
+        required: false
+      agent_token_cap:
+        description: "With run_language_agent: best-effort token cap; 0 disables. Blank = 5762100."
+        required: false
+      agent_turn_cap:
+        description: "With run_language_agent: completed-turn cap; 0 disables. Blank = 20."
+        required: false
       dry_run:
         description: "Full pipeline (build, bump, snapshot regen, test-lang) but push nothing: no PR here, integrate job skipped."
         type: boolean
@@ -67,6 +80,9 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+      # scripts/propose-grammar-update is a uv script
+      - name: Install the latest version of uv
+        uses: ./.github/actions/setup-uv
       - id: list
         # A single dispatched language overrides the full set. The input is
         # untrusted, so it goes through an env var (never interpolated into
@@ -82,21 +98,21 @@ jobs:
           if [ -n "$INPUT_LANGUAGE" ] && [ "$INPUT_LANGUAGE" != "all" ]; then
             # Single named language: validate against the FULL set (a manual
             # run may target a language even just to re-check it — no filter).
-            valid=$(python scripts/propose-grammar-update --list-languages --json)
+            valid=$(uv run --script scripts/propose-grammar-update --list-languages --json)
             echo "$valid" | python -c "import json,sys; ls=json.load(sys.stdin); sys.exit(0 if sys.argv[1] in ls else 1)" "$INPUT_LANGUAGE" \
               || { echo "Unknown language: $INPUT_LANGUAGE" >&2; exit 1; }
             echo "languages=$(python -c 'import json,os; print(json.dumps([os.environ["INPUT_LANGUAGE"]]))')" >> "$GITHUB_OUTPUT"
           else
             # 'all'/blank/scheduled: only languages actually behind their latest
             # tag, so up-to-date ones never enter the expensive build matrix.
-            echo "languages=$(python scripts/propose-grammar-update --list-languages --updatable-only --json)" >> "$GITHUB_OUTPUT"
+            echo "languages=$(uv run --script scripts/propose-grammar-update --list-languages --updatable-only --json)" >> "$GITHUB_OUTPUT"
           fi
 
   propose:
     name: Propose ${{ matrix.language }}
     needs: enumerate
     runs-on: ubuntu-latest
-    timeout-minutes: 45   # OCaml build (~15m) + test-lang + possible review agent
+    timeout-minutes: 45   # OCaml build (~15m) + test-lang + possible language agent
     strategy:
       fail-fast: false
       max-parallel: 4
@@ -172,15 +188,10 @@ jobs:
       # This step must come AFTER `make install` populates that dir.
       - name: Put pinned tree-sitter CLI on PATH
         run: echo "$GITHUB_WORKSPACE/core/tree-sitter/bin" >> "$GITHUB_PATH"
-      # The review agent (Cursor dispatch on a failing test-lang) is an
-      # explicit opt-in via the run_review_agent input: without it, neither
-      # the CLI nor the API key is even present on the runner, so no grammar
-      # source or test logs can ever leave it.
-      - name: Install Cursor agent CLI
-        if: inputs.run_review_agent
-        run: |
-          curl https://cursor.com/install -fsS | bash
-          echo "$HOME/.cursor/bin" >> "$GITHUB_PATH"
+      # uv script: PEP 723 pulls cursor-sdk; language agent still needs
+      # run_language_agent + CURSOR_API_KEY to actually dispatch.
+      - name: Install the latest version of uv
+        uses: ./.github/actions/setup-uv
       - name: Propose update
         env:
           # NOTE: PRs created with GITHUB_TOKEN do not trigger other GitHub
@@ -189,8 +200,12 @@ jobs:
           # triggers via its own webhook integration. If Actions CI on these
           # PRs is wanted later, swap in a PAT / GitHub App token here.
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          CURSOR_API_KEY: ${{ inputs.run_review_agent && secrets.CURSOR_API_KEY || '' }}
-          RUN_REVIEW_AGENT: ${{ inputs.run_review_agent }}
+          CURSOR_API_KEY: ${{ inputs.run_language_agent && secrets.CURSOR_API_KEY || '' }}
+          RUN_LANGUAGE_AGENT: ${{ inputs.run_language_agent }}
+          VERBOSE_LANGUAGE_AGENT: ${{ inputs.verbose_language_agent }}
+          AGENT_TIMEOUT: ${{ inputs.agent_timeout }}
+          AGENT_TOKEN_CAP: ${{ inputs.agent_token_cap }}
+          AGENT_TURN_CAP: ${{ inputs.agent_turn_cap }}
           DRY_RUN: ${{ inputs.dry_run }}
         run: |
           # bash -e omits pipefail; without it `| tee` hides script failures
@@ -202,8 +217,14 @@ jobs:
           mode="--open-pr"
           if [ "$DRY_RUN" = "true" ]; then mode="--dry-run"; fi
           flags=""
-          if [ "$RUN_REVIEW_AGENT" = "true" ]; then flags="--review-agent"; fi
-          opam exec -- python scripts/propose-grammar-update "${{ matrix.language }}" $mode $flags \
+          if [ "$RUN_LANGUAGE_AGENT" = "true" ]; then flags="--language-agent"; fi
+          if [ "$VERBOSE_LANGUAGE_AGENT" = "true" ]; then flags="$flags --verbose"; fi
+          # Blank inputs (the default) omit the flag so the script's own
+          # default applies — see propose-grammar-update --help.
+          if [ -n "$AGENT_TIMEOUT" ]; then flags="$flags --agent-timeout $AGENT_TIMEOUT"; fi
+          if [ -n "$AGENT_TOKEN_CAP" ]; then flags="$flags --agent-token-cap $AGENT_TOKEN_CAP"; fi
+          if [ -n "$AGENT_TURN_CAP" ]; then flags="$flags --agent-turn-cap $AGENT_TURN_CAP"; fi
+          opam exec -- uv run --script scripts/propose-grammar-update "${{ matrix.language }}" $mode $flags \
             | tee "result-${{ matrix.language }}.json"
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always()
@@ -300,7 +321,10 @@ jobs:
         name: Put pinned tree-sitter CLI on PATH
         run: echo "$GITHUB_WORKSPACE/core/tree-sitter/bin" >> "$GITHUB_PATH"
       - if: steps.gate.outputs.go == 'true'
-        name: Release to semgrep-${{ matrix.language }}
+        name: Install the latest version of uv
+        uses: ./.github/actions/setup-uv
+      - if: steps.gate.outputs.go == 'true'
+        name: Release to semgrep-${ matrix.language }
         env:
           # Pushing to the downstream semgrep-<lang> repos needs broader
           # creds than GITHUB_TOKEN.
@@ -316,7 +340,7 @@ jobs:
           # lang/release -> make gen-c needs `ocaml-tree-sitter` on PATH.
           # --result: release the exact tag/branch the propose job validated
           # (from its artifact), never a live re-resolved one.
-          opam exec -- python scripts/propose-grammar-update "${{ matrix.language }}" --release \
+          opam exec -- uv run --script scripts/propose-grammar-update "${{ matrix.language }}" --release \
             --result "result/result-${{ matrix.language }}.json"
 
   summary:
@@ -337,8 +361,10 @@ jobs:
         with:
           path: results
           merge-multiple: true
+      - name: Install the latest version of uv
+        uses: ./.github/actions/setup-uv
       - name: Render summary
-        run: python scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
+        run: uv run --script scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
 
   # Slack notification (LANG-604): pages #team-languages when any job fails,
   # posts a success note (with PR links) when update PRs were opened, and a
@@ -366,6 +392,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+      - name: Install the latest version of uv
+        uses: ./.github/actions/setup-uv
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         # A crash before any propose leg wrote its result (e.g. enumerate
         # failed) leaves no artifacts; the alert then falls back to
@@ -414,7 +442,7 @@ jobs:
           # Row count is bounded by the language set (~47), well under
           # Slack's 40k text limit.
           if [ "$have_results" = true ]; then
-            summary=$(python scripts/propose-grammar-update --summarize results || true)
+            summary=$(uv run --script scripts/propose-grammar-update --summarize results || true)
             text="${text}"$'\n```\n'"${summary}"$'\n```'
           fi
           if [ "$TEST_MODE" = "true" ]; then text=":test_tube: [test mode] ${text}"; fi

--- a/.github/workflows/python-tests.yml
+++ b/.github/workflows/python-tests.yml
@@ -45,6 +45,10 @@ jobs:
             "$dir/tree-sitter" --version
           done
 
+      # scripts/test_propose_grammar_update.py is a uv script (see make test-python).
+      - name: Install the latest version of uv
+        uses: ./.github/actions/setup-uv
+
       - name: Run Python tests (make test-python)
         run: |
           python -m pip install --upgrade pip

--- a/Makefile
+++ b/Makefile
@@ -50,7 +50,10 @@ test: build
 # Run the Python test suites (not run by 'make test'). For full coverage, the
 # pinned tree-sitter versions must be installed ('make setup-tree-sitter-versions').
 # Uses the 'pytest' on PATH if present, otherwise falls back to 'python3 -m pytest'.
-PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_propose_grammar_update.py
+# scripts/test_propose_grammar_update.py MUST run as a separate invocation (via
+# 'uv run'): it's a uv script with its own pinned deps (cursor-sdk, see its inline
+# metadata) that a bare pytest/python3 invocation can't install.
+PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_cursor_agent_runner.py
 .PHONY: test-python
 test-python:
 	@if command -v pytest >/dev/null 2>&1; then \
@@ -58,6 +61,7 @@ test-python:
 	else \
 	  python3 -m pytest $(PYTHON_TESTS); \
 	fi
+	uv run scripts/test_propose_grammar_update.py
 
 # Install every tree-sitter version the grammars are pinned to (derived from the
 # lang/languages-* files), each into its own core/tree-sitter-<version>/. Needed

--- a/Makefile
+++ b/Makefile
@@ -50,9 +50,8 @@ test: build
 # Run the Python test suites (not run by 'make test'). For full coverage, the
 # pinned tree-sitter versions must be installed ('make setup-tree-sitter-versions').
 # Uses the 'pytest' on PATH if present, otherwise falls back to 'python3 -m pytest'.
-# scripts/test_propose_grammar_update.py MUST run as a separate invocation (via
-# 'uv run'): it's a uv script with its own pinned deps (cursor-sdk, see its inline
-# metadata) that a bare pytest/python3 invocation can't install.
+# scripts/test_propose_grammar_update.py MUST run as a separate invocation:
+# it's a uv script with its own pinned deps.
 PYTHON_TESTS = lang/test_grammar_ts_version.py lang/test_ts_versions.py lang/test_abi15_gating.py scripts/test_update_grammar.py scripts/test_cursor_agent_runner.py
 .PHONY: test-python
 test-python:

--- a/scripts/cursor_agent_runner.py
+++ b/scripts/cursor_agent_runner.py
@@ -1,0 +1,281 @@
+"""Generic Cursor SDK agent dispatch: wall-clock timeout, best-effort token/turn
+caps, and heartbeat-or-verbose event logging. Callers pass a plain prompt
+string in; this module knows nothing about grammars, languages, or tags.
+
+Environment variables:
+  CURSOR_API_KEY   Required to actually dispatch; read by the cursor_sdk
+                    itself, never by this module.
+  CURSOR_MODEL      Model for the agent (default: "auto").
+"""
+
+from __future__ import annotations
+
+import argparse
+import datetime
+import os
+import sys
+import threading
+import time
+import traceback
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+
+def log(msg: str) -> None:
+    """Print a human-facing progress line to stderr."""
+    print(msg, file=sys.stderr)
+
+
+# Best-effort: enforced at turn boundaries only (see run_language_agent).
+# 10x the one measured bump (solidity v1.2.13: ~576k tokens).
+DEFAULT_AGENT_TOKEN_CAP = 5_762_100
+
+# Soft guess aligned with fix-semgrep-grammar's max-iterations default; not
+# yet calibrated against measured bumps.
+DEFAULT_AGENT_TURN_CAP = 20
+
+DEFAULT_AGENT_TIMEOUT = "25m"
+
+
+def parse_duration_seconds(duration_str: str) -> float:
+    """argparse `type=` for a CLI duration flag: '30s' / '25m' / '2h' or bare seconds.
+
+    Raises argparse.ArgumentTypeError on anything else, so a bad CLI value is
+    a clean usage error rather than a silently-substituted default.
+    """
+    s = duration_str.strip()
+    try:
+        if s.endswith('s'):
+            duration = datetime.timedelta(seconds=int(s[:-1]))
+        elif s.endswith('m'):
+            duration = datetime.timedelta(minutes=int(s[:-1]))
+        elif s.endswith('h'):
+            duration = datetime.timedelta(hours=int(s[:-1]))
+        else:
+            duration = datetime.timedelta(seconds=int(s))
+    except (ValueError, IndexError):
+        raise argparse.ArgumentTypeError(
+            f"invalid duration {duration_str!r} (expected e.g. '30s', '25m', '2h')")
+    return duration.total_seconds()
+
+
+def cap_or_none(n: int) -> int | None:
+    """CLI convention for cap flags: <= 0 means disabled."""
+    return n if n > 0 else None
+
+
+@dataclass
+class LanguageAgentResult:
+    input_tokens: int = 0
+    output_tokens: int = 0
+    turns: int = 0
+    capped_reason: str | None = None
+
+
+def _log_agent_message(msg: Any) -> None:
+    """Log one SDK message to stderr; usage is handled by the caller."""
+    match getattr(msg, "type", None):
+        case "assistant":
+            for block in getattr(getattr(msg, "message", None), "content", ()):
+                text = getattr(block, "text", "")
+                if text:
+                    sys.stderr.write(f"[agent] {text}\n")
+        case "thinking":
+            sys.stderr.write(f"[agent:thinking] {msg.text}\n")
+        case "tool_call":
+            sys.stderr.write(f"[agent:tool] {msg.name} ({msg.status})\n")
+        case "status":
+            sys.stderr.write(f"[agent:status] {msg.status}: {msg.message}\n")
+        case "usage":
+            pass
+        case kind:
+            sys.stderr.write(f"[agent:{kind}] {msg}\n")
+
+
+def _log_interaction_update(update: Any) -> None:
+    """Log one interaction_update event (--verbose only)."""
+    match getattr(update, "type", None):
+        case "tool-call-started" | "tool-call-completed":
+            tool_call = getattr(update, "tool_call", None) or {}
+            name = tool_call.get("name") or tool_call.get("tool") or "tool"
+            sys.stderr.write(f"[agent:{update.type}] {name}\n")
+        case "step-started":
+            sys.stderr.write(f"[agent:step-started] {update.step_id}\n")
+        case "step-completed":
+            sys.stderr.write(
+                f"[agent:step-completed] {update.step_id} ({update.step_duration_ms}ms)\n")
+        case "text-delta" | "thinking-delta":
+            if update.text:
+                sys.stderr.write(update.text)
+        case "shell-output-delta":
+            event = getattr(update, "event", None) or {}
+            chunk = event.get("chunk") or event.get("data") or ""
+            if chunk:
+                sys.stderr.write(chunk)
+        case _:
+            pass
+
+
+def _heartbeat_loop(stop: threading.Event, label: str, interval: float = 30.0) -> None:
+    """Periodic liveness line so GHA doesn't kill a quiet step (~10m)."""
+    start = time.monotonic()
+    while not stop.wait(interval):
+        elapsed = int(time.monotonic() - start)
+        log(f"[agent] still working on {label}... ({elapsed}s elapsed)")
+
+
+def ensure_cursor_sdk() -> None:
+    """Fail fast if cursor-sdk is missing (only when the caller opted in)."""
+    try:
+        import cursor_sdk  # noqa: F401
+    except ImportError:
+        log("Error: cursor-sdk not installed. Install with: pip install cursor-sdk")
+        sys.exit(1)
+
+
+def _cancel_if_running(run: Any) -> None:
+    """Cancel only while running (terminal cancel errors on SDK 1.0.23+)."""
+    if getattr(run, "status", None) == "running":
+        run.cancel()
+
+
+def _trip_cap(result: LanguageAgentResult, run: Any, timer: threading.Timer,
+             reason: str, message: str) -> None:
+    """Record a cap reason (first one wins), log it, and cancel the run."""
+    if result.capped_reason is None:
+        result.capped_reason = reason
+        log(f"[agent] cancelled: {message}")
+    timer.cancel()
+    _cancel_if_running(run)
+
+
+def _log_run_failure(run_result: Any) -> None:
+    """Log structured error from run.wait() if status is error."""
+    if run_result is None or getattr(run_result, "status", None) != "error":
+        return
+    err = getattr(run_result, "error", None)
+    message = getattr(err, "message", None) or getattr(run_result, "result", None) or "unknown"
+    code = getattr(err, "code", None)
+    log(f"Language agent run error: {message}" + (f" (code={code})" if code else ""))
+
+
+def run_language_agent(root: Path, prompt: str, *, label: str = "agent",
+                     verbose: bool = False,
+                     timeout_seconds: float = 1500.0,
+                     token_cap: int | None = DEFAULT_AGENT_TOKEN_CAP,
+                     turn_cap: int | None = DEFAULT_AGENT_TURN_CAP) -> LanguageAgentResult:
+    """Run the Cursor SDK agent on `prompt`; return token usage / cap info.
+
+    Best-effort: the caller judges success (e.g. by re-running whatever check
+    the prompt was meant to fix). `label` is only used for logging. Token/turn
+    caps are best-effort and turn-boundary only — a single turn can overrun.
+    verbose=True logs the full event stream; otherwise a heartbeat only.
+    """
+    log(f"$ cursor agent <{label}>  (in {root})")
+
+    result = LanguageAgentResult()
+
+    try:
+        # Lazy import so tests can inject a fake via sys.modules.
+        from cursor_sdk import Agent, LocalAgentOptions
+
+        # force=True clears a leftover active local session.
+        with Agent.create(
+            model=os.environ.get("CURSOR_MODEL", "auto"),  # SDK requires non-empty
+            local=LocalAgentOptions(cwd=root),
+        ) as agent:
+            run = agent.send(prompt, {"local": {"force": True}})
+
+            def cancel_on_timeout():
+                if result.capped_reason is None:
+                    result.capped_reason = "wall_clock_timeout"
+                    log(f"[agent] cancelled: wall-clock timeout "
+                        f"({timeout_seconds:.0f}s)")
+                _cancel_if_running(run)
+
+            timer = threading.Timer(timeout_seconds, cancel_on_timeout)
+            timer.daemon = True
+            timer.start()
+
+            heartbeat_stop = threading.Event()
+            heartbeat = None
+            if not verbose:
+                heartbeat = threading.Thread(
+                    target=_heartbeat_loop, args=(heartbeat_stop, label),
+                    daemon=True,
+                )
+                heartbeat.start()
+
+            # Token cap is best-effort at turn boundaries (usage messages).
+            # streamed_tokens folds in token-delta updates so a cap trips
+            # before the next usage message, when the runtime emits them.
+            streamed_tokens = 0
+
+            try:
+                for item in run.events():
+                    if item.kind == "interaction_update":
+                        update = item.interaction_update
+                        if verbose:
+                            _log_interaction_update(update)
+                        if (token_cap is not None
+                                and getattr(update, "type", None) == "token-delta"):
+                            streamed_tokens += int(getattr(update, "tokens", 0) or 0)
+                            used = (result.input_tokens + result.output_tokens
+                                    + streamed_tokens)
+                            if used >= token_cap:
+                                # Fold the in-flight estimate into reported totals.
+                                result.output_tokens = (
+                                    result.output_tokens + streamed_tokens)
+                                _trip_cap(result, run, timer, "token_cap",
+                                          f"best-effort token cap ({used} >= "
+                                          f"{token_cap}; turn-boundary only)")
+                                break
+                        continue
+
+                    msg = item.sdk_message
+                    if msg is None:
+                        continue
+                    if verbose:
+                        _log_agent_message(msg)
+                    if getattr(msg, "type", None) == "usage" and msg.usage is not None:
+                        # Prefer cumulative handle totals when the SDK has them.
+                        usage = getattr(run, "usage", None) or msg.usage
+                        result.input_tokens = usage.input_tokens
+                        result.output_tokens = usage.output_tokens
+                        streamed_tokens = 0
+                        result.turns += 1
+                        used = result.input_tokens + result.output_tokens
+                        if token_cap is not None and used >= token_cap:
+                            _trip_cap(result, run, timer, "token_cap",
+                                      f"best-effort token cap ({used} >= "
+                                      f"{token_cap}; turn-boundary only)")
+                            break
+                        if turn_cap is not None and result.turns >= turn_cap:
+                            _trip_cap(result, run, timer, "turn_cap",
+                                      f"turn cap ({result.turns} >= {turn_cap})")
+                            break
+
+                run_result = run.wait()
+                # After a token-/turn-cap cancel, keep the stream's last usage —
+                # wait() may return None/stale totals once the run is cancelled.
+                if (result.capped_reason is None
+                        and run_result is not None
+                        and run_result.usage is not None):
+                    result.input_tokens = run_result.usage.input_tokens
+                    result.output_tokens = run_result.usage.output_tokens
+                _log_run_failure(run_result)
+
+            finally:
+                if heartbeat is not None:
+                    heartbeat_stop.set()
+                    heartbeat.join(timeout=1)
+                timer.cancel()
+
+    except Exception as e:
+        request_id = getattr(e, "request_id", None)
+        suffix = f" (request_id={request_id})" if request_id else ""
+        log(f"Language agent dispatch error: {e}{suffix}")
+        log(traceback.format_exc())
+
+    return result

--- a/scripts/cursor_agent_runner.py
+++ b/scripts/cursor_agent_runner.py
@@ -140,14 +140,24 @@ def _cancel_if_running(run: Any) -> None:
         run.cancel()
 
 
-def _trip_cap(result: LanguageAgentResult, run: Any, timer: threading.Timer,
-             reason: str, message: str) -> None:
-    """Record a cap reason (first one wins), log it, and cancel the run."""
-    if result.capped_reason is None:
+def _claim_cap(result: LanguageAgentResult, lock: threading.Lock,
+               reason: str, message: str) -> bool:
+    """Atomically claim the cancel reason. First caller wins; returns True if claimed."""
+    with lock:
+        if result.capped_reason is not None:
+            return False
         result.capped_reason = reason
-        log(f"[agent] cancelled: {message}")
+    log(f"[agent] cancelled: {message}")
+    return True
+
+
+def _trip_cap(result: LanguageAgentResult, run: Any, timer: threading.Timer,
+             lock: threading.Lock, reason: str, message: str) -> None:
+    """Claim a cap reason (first one wins), cancel the timer, and cancel the run once."""
+    claimed = _claim_cap(result, lock, reason, message)
     timer.cancel()
-    _cancel_if_running(run)
+    if claimed:
+        _cancel_if_running(run)
 
 
 def _log_run_failure(run_result: Any) -> None:
@@ -186,13 +196,15 @@ def run_language_agent(root: Path, prompt: str, *, label: str = "agent",
             local=LocalAgentOptions(cwd=root),
         ) as agent:
             run = agent.send(prompt, {"local": {"force": True}})
+            # Shared by the event-loop thread (_trip_cap) and the Timer thread
+            # (cancel_on_timeout): unsynchronized check-then-act on
+            # capped_reason races to a log/state mismatch and double-cancel.
+            cap_lock = threading.Lock()
 
             def cancel_on_timeout():
-                if result.capped_reason is None:
-                    result.capped_reason = "wall_clock_timeout"
-                    log(f"[agent] cancelled: wall-clock timeout "
-                        f"({timeout_seconds:.0f}s)")
-                _cancel_if_running(run)
+                if _claim_cap(result, cap_lock, "wall_clock_timeout",
+                              f"wall-clock timeout ({timeout_seconds:.0f}s)"):
+                    _cancel_if_running(run)
 
             timer = threading.Timer(timeout_seconds, cancel_on_timeout)
             timer.daemon = True
@@ -227,7 +239,7 @@ def run_language_agent(root: Path, prompt: str, *, label: str = "agent",
                                 # Fold the in-flight estimate into reported totals.
                                 result.output_tokens = (
                                     result.output_tokens + streamed_tokens)
-                                _trip_cap(result, run, timer, "token_cap",
+                                _trip_cap(result, run, timer, cap_lock, "token_cap",
                                           f"best-effort token cap ({used} >= "
                                           f"{token_cap}; turn-boundary only)")
                                 break
@@ -247,12 +259,12 @@ def run_language_agent(root: Path, prompt: str, *, label: str = "agent",
                         result.turns += 1
                         used = result.input_tokens + result.output_tokens
                         if token_cap is not None and used >= token_cap:
-                            _trip_cap(result, run, timer, "token_cap",
+                            _trip_cap(result, run, timer, cap_lock, "token_cap",
                                       f"best-effort token cap ({used} >= "
                                       f"{token_cap}; turn-boundary only)")
                             break
                         if turn_cap is not None and result.turns >= turn_cap:
-                            _trip_cap(result, run, timer, "turn_cap",
+                            _trip_cap(result, run, timer, cap_lock, "turn_cap",
                                       f"turn cap ({result.turns} >= {turn_cap})")
                             break
 

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -1,4 +1,19 @@
-#!/usr/bin/env python3
+#!/usr/bin/env -S uv run --script
+# uv (not pip) so `cursor-sdk` installs cleanly everywhere, including macOS
+# Homebrew Python, whose externally-managed-environment guard rejects a bare
+# `pip install`.
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     # Pin by hand after checking the cursor-sdk changelog.
+#     "cursor-sdk==1.0.24",
+# ]
+#
+# [tool.uv]
+# # Transitive cooldown; cursor-sdk exempt so a fresh pin installs immediately.
+# exclude-newer = "1 week"
+# exclude-newer-package = { cursor-sdk = false }
+# ///
 """Propose an upstream grammar update for a single language.
 
 This is the per-language driver behind the scheduled "propose grammar
@@ -24,16 +39,31 @@ Modes:
       array for the workflow matrix).
   propose-grammar-update <language> --resolve-tag-only
       Print the latest stable tag for <language> and exit (no mutation).
-  propose-grammar-update <language> [--open-pr] [--dry-run] [--review-agent]
+  propose-grammar-update <language> [--open-pr] [--dry-run] [--language-agent]
       Bump <language> to its latest tag, regenerate snapshots, test, and
       emit a JSON result. With --open-pr, also create the PR; --dry-run
-      prints the would-be PR instead of pushing. --review-agent (explicit
+      prints the would-be PR instead of pushing. --language-agent (explicit
       opt-in) dispatches a Cursor agent to adapt tests on a test-lang
       failure; without it a failing bump is simply reported as failed.
   propose-grammar-update <language> --release [--result FILE]
       Downstream step: release the validated parser branch to
       semgrep-<lang> via PR. semgrep-proprietary integration is left to
       the existing Cursor workflow on that repo — not handled here.
+
+Wall-clock timeout / token cap / turn cap for the language agent are CLI flags
+(--agent-timeout / --agent-token-cap / --agent-turn-cap), not env vars — see
+--help. The agent's model and credentials remain environment-based since
+they're read by the cursor_sdk itself, not this script.
+
+Environment variables:
+  GH_TOKEN / GITHUB_TOKEN   Required by every `gh` call (PR/label create,
+                            repo lookups). --release needs broader creds
+                            (push to semgrep-<lang>) than --open-pr.
+  CURSOR_API_KEY            Required only with --language-agent; read by the
+                            cursor_sdk itself, never by this script.
+  CURSOR_MODEL              Model for the language agent (default: "auto").
+  GRAMMAR_BASE_BRANCH       Base branch for grammar-update PRs
+                            (default: "main").
 """
 
 from __future__ import annotations
@@ -89,6 +119,19 @@ def _load_ts_versions() -> Any:
 
 
 ts_versions = _load_ts_versions()
+
+# cursor_agent_runner.py has a normal extension and no top-level cursor_sdk
+# import, so a plain import works once its directory is on sys.path.
+sys.path.insert(0, str(_SCRIPT_DIR))
+from cursor_agent_runner import (  # noqa: E402
+    DEFAULT_AGENT_TOKEN_CAP,
+    DEFAULT_AGENT_TURN_CAP,
+    DEFAULT_AGENT_TIMEOUT,
+    cap_or_none,
+    ensure_cursor_sdk,
+    parse_duration_seconds,
+    run_language_agent,
+)
 
 ###############################################################################
 # Types #
@@ -156,6 +199,10 @@ class Result:
     branch: str | None = None
     pr_url: str | None = None
     version_note: str | None = None
+    agent_input_tokens: int | None = None
+    agent_output_tokens: int | None = None
+    agent_turns: int | None = None
+    agent_capped_reason: str | None = None
 
     def to_json(self) -> str:
         return json.dumps({k: v for k, v in asdict(self).items() if v is not None})
@@ -170,7 +217,6 @@ class Result:
 ###############################################################################
 # Helpers #
 ###############################################################################
-
 
 def log(msg: str) -> None:
     """Print a human-facing progress line to stderr (stdout is for JSON)."""
@@ -996,9 +1042,9 @@ def open_pr(root: Path, target: Target, result: Result,
     return result
 
 
-def review_agent_prompt(lang: LangAndWrapper, tag: str,
+def language_agent_prompt(lang: LangAndWrapper, tag: str,
                         test_log: str) -> str:
-    """Prompt that drives Marc-André's `fix-semgrep-grammar` skill.
+    """Prompt that drives the `fix-semgrep-grammar` skill.
 
     That skill (`.agents/skills/fix-semgrep-grammar/SKILL.md`, from #619) is
     the purpose-built tool for repairing the semgrep extension grammar +
@@ -1019,61 +1065,29 @@ def review_agent_prompt(lang: LangAndWrapper, tag: str,
     )
 
 
-def agent_cmd(prompt: str) -> list[str]:
-    """Build the Cursor `agent` command for headless CI execution.
-
-    `-p` is print/non-interactive mode; `--force` auto-approves file edits
-    and command execution (without it the agent stops at an interactive
-    permission prompt and does nothing in CI). `--output-format json` makes
-    the result parseable. Model overridable via CURSOR_MODEL.
-    """
-    cmd = ["agent", "-p", "--force", "--output-format", "json"]
-    model = os.environ.get("CURSOR_MODEL")
-    if model:
-        cmd += ["--model", model]
-    cmd.append(prompt)
-    # Hard wall-clock bound so a stuck agent session can't burn the whole job
-    # (a bounded loop cap the CLI doesn't expose). `timeout` returns 124 on
-    # expiry; callers treat a non-zero agent as best-effort. Override via
-    # CURSOR_AGENT_TIMEOUT (default 25m, comfortably inside the 45m job cap).
-    limit = os.environ.get("CURSOR_AGENT_TIMEOUT", "25m")
-    return ["timeout", limit, *cmd]
-
-
-def run_review_agent(root: Path, lang: LangAndWrapper, tag: str,
-                     test_log: str) -> None:
-    """Invoke the Cursor agent to review + adapt tests for a failing bump.
-
-    Runs in-repo (cwd = root). Output to stderr to keep stdout JSON-pure.
-    Best-effort: the authoritative signal is the test-lang RE-RUN the
-    caller does afterward, so we don't raise on the agent's own exit code.
-    """
-    prompt = review_agent_prompt(lang, tag, test_log)
-    log(f"$ agent -p --force <review prompt for {lang.language}>  (in {root})")
-    r = subprocess.run(agent_cmd(prompt), cwd=root, text=True,
-                       capture_output=True, check=False)
-    sys.stderr.write(r.stdout)
-    sys.stderr.write(r.stderr)
-
-
 def propose(root: Path, target: Target, keep: bool = False,
-            review_agent: bool = False) -> Result:
+            language_agent: bool = False, verbose: bool = False,
+            agent_timeout: float = 1500.0,
+            agent_token_cap: int | None = DEFAULT_AGENT_TOKEN_CAP,
+            agent_turn_cap: int | None = DEFAULT_AGENT_TURN_CAP) -> Result:
     """Run the full single-language propose flow; return a Result.
 
     Bumps to the latest tag, regenerates snapshots, runs test-lang, and
-    classifies the outcome. On a test-lang failure, `review_agent=True`
+    classifies the outcome. On a test-lang failure, `language_agent=True`
     dispatches the fix-semgrep-grammar skill to adapt the tests, then
     test-lang is re-run (the authoritative signal); with the default
-    `review_agent=False` the failure is reported as-is — no Cursor agent is
+    `language_agent=False` the failure is reported as-is — no Cursor agent is
     ever launched unless the caller opted in. With `keep=True`, the work is
     done on the grammar-update branch (forked from origin/main) and the
     validated tree is committed there for open_pr() to push — no re-bump,
     no second agent run. With keep=False (classify-only), the working tree
-    is reset before returning.
+    is reset before returning. `verbose`/`agent_timeout`/`agent_token_cap`/
+    `agent_turn_cap` only affect language-agent behavior.
     Does NOT create a PR — that's the caller's job under --open-pr.
     """
     lang = target.lang
     language = lang.language
+    step = lambda msg: log(f"[{language}] {msg}")
     tag = target.tag
     result = Result(language=language, ts_version=target.ts_version, new_tag=tag)
     if target.resolution_note:
@@ -1091,7 +1105,7 @@ def propose(root: Path, target: Target, keep: bool = False,
     submodule = target.submodule
     old_sha = submodule_head(submodule)
     result.old_sha = old_sha
-    log(f"[{language}] {old_sha[:8]} -> {tag}")
+    step(f"{old_sha[:8]} -> {tag}")
 
     # In `keep` (PR) mode, do all the work directly on the grammar-update
     # branch forked from origin/main, and DON'T reset — the validated tree
@@ -1113,7 +1127,7 @@ def propose(root: Path, target: Target, keep: bool = False,
         # our re-run below is the authoritative signal. But an unchanged
         # submodule is only a real no-op if the bump itself succeeded —
         # otherwise it failed before doing anything and must be surfaced.
-        log(f"[{language}] bumping submodule to {tag}")
+        step(f"bumping submodule to {tag}")
         bump = run_update_grammar(lang, target.ts_version, tag, root)
         new_sha = submodule_head(submodule)
         result.new_sha = new_sha
@@ -1123,31 +1137,39 @@ def propose(root: Path, target: Target, keep: bool = False,
                 result.status = STATUS_FAILED
                 result.detail = "update-grammar failed"
                 result.test_log_tail = tail(bump.stdout + bump.stderr)
-                log(f"[{language}] update-grammar failed; nothing moved")
+                step("update-grammar failed; nothing moved")
                 return result
             result.status = STATUS_NO_OP
-            log(f"[{language}] already at {tag}; no-op")
+            step(f"already at {tag}; no-op")
             return result
 
         # Snapshots are expected to churn; regenerate then test for the
         # authoritative result.
-        log(f"[{language}] regenerating corpus snapshots")
+        step("regenerating corpus snapshots")
         regenerate_snapshots(root, lang, target.ts_version)
         result.corpus_diff = corpus_diff(root, lang)
-        log(f"[{language}] running test-lang")
+        step("running test-lang")
         test = run_test_lang(lang, root)
         result.test_log_tail = tail(test.stdout + test.stderr)
 
-        if test.returncode != 0 and review_agent:
+        if test.returncode != 0 and language_agent:
             # test-lang failed — most often a mechanical upstream CST rename
             # that broke existing corpus snapshots. Invoke the fix-semgrep-
             # grammar skill to adapt the tests, then re-test as the
             # authoritative signal (the skill's own status is advisory).
-            log(f"[{language}] test-lang failed; dispatching review agent")
-            run_review_agent(root, lang, tag,
-                             test.stdout + test.stderr)
+            step("test-lang failed; dispatching language agent")
+            prompt = language_agent_prompt(lang, tag, test.stdout + test.stderr)
+            agent_result = run_language_agent(root, prompt, label=language,
+                                             verbose=verbose,
+                                             timeout_seconds=agent_timeout,
+                                             token_cap=agent_token_cap,
+                                             turn_cap=agent_turn_cap)
+            result.agent_input_tokens = agent_result.input_tokens
+            result.agent_output_tokens = agent_result.output_tokens
+            result.agent_turns = agent_result.turns
+            result.agent_capped_reason = agent_result.capped_reason
             result.corpus_diff = corpus_diff(root, lang)
-            log(f"[{language}] re-running test-lang after review agent")
+            step("re-running test-lang after language agent")
             test = run_test_lang(lang, root)
             result.test_log_tail = tail(test.stdout + test.stderr)
             if test.returncode == 0:
@@ -1155,12 +1177,12 @@ def propose(root: Path, target: Target, keep: bool = False,
 
         if test.returncode != 0:
             result.status = STATUS_FAILED
-            result.detail = ("test-lang failed (review agent could not fix it)"
-                             if review_agent else
-                             "test-lang failed (review agent not enabled)")
+            result.detail = ("test-lang failed (language agent could not fix it)"
+                             if language_agent else
+                             "test-lang failed (language agent not enabled)")
             if not result.test_log_tail:
                 result.test_log_tail = tail(bump.stdout + bump.stderr)
-            log(f"[{language}] {result.detail}")
+            step(f"{result.detail}")
             return result
 
         result.status = STATUS_UPDATED
@@ -1168,14 +1190,14 @@ def propose(root: Path, target: Target, keep: bool = False,
             # Commit the validated tree on the branch — this is exactly what
             # was tested. Exclude the workflow's result artifact and `core`
             # (a grammar bump must only move the language submodule).
-            log(f"[{language}] committing validated tree on {branch}")
+            step(f"committing validated tree on {branch}")
             run_quiet(["git", "add", "-A", "--", ".",
                        ":(exclude)result-*.json", ":(exclude)core"], cwd=root)
             run_quiet(["git", "commit", "-m",
                        f"Update tree-sitter-{lang.language} grammar to {tag}"], cwd=root)
             committed = True
             result.branch = branch
-        log(f"[{language}] updated: {tag}")
+        step(f"updated: {tag}")
         return result
     except Exception as e:
         # Return failed Result (language set) instead of raising.
@@ -1448,12 +1470,36 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         help="Print would-be PR / release actions instead of running them.",
     )
     parser.add_argument(
-        "--review-agent", action="store_true",
+        "--language-agent", action="store_true",
         help="On test-lang failure, dispatch a Cursor agent (the "
              "fix-semgrep-grammar skill) to adapt the extension grammar/tests, "
              "then re-run test-lang. OFF by default: sends grammar source and "
              "test logs to Cursor, so it must be explicitly opted into "
              "(needs CURSOR_API_KEY).",
+    )
+    parser.add_argument(
+        "--verbose", action="store_true",
+        help="With --language-agent, log the full event stream instead of a "
+             "heartbeat (can be very noisy).",
+    )
+    parser.add_argument(
+        "--agent-timeout", type=parse_duration_seconds,
+        default=parse_duration_seconds(DEFAULT_AGENT_TIMEOUT),
+        metavar="DURATION",
+        help="With --language-agent: wall-clock cap for the agent, e.g. '30s', "
+             f"'25m', '2h' (default: {DEFAULT_AGENT_TIMEOUT}).",
+    )
+    parser.add_argument(
+        "--agent-token-cap", type=int, default=DEFAULT_AGENT_TOKEN_CAP,
+        metavar="N",
+        help="With --language-agent: best-effort token cap, enforced at turn "
+             f"boundaries only; 0 disables (default: {DEFAULT_AGENT_TOKEN_CAP}).",
+    )
+    parser.add_argument(
+        "--agent-turn-cap", type=int, default=DEFAULT_AGENT_TURN_CAP,
+        metavar="N",
+        help="With --language-agent: completed-turn cap; 0 disables "
+             f"(default: {DEFAULT_AGENT_TURN_CAP}).",
     )
     parser.add_argument(
         "--release", action="store_true",
@@ -1568,6 +1614,10 @@ def main() -> int:
         if args.release:
             return run_release(root, target, args.dry_run, result_file=args.result)
 
+        # Before any propose() mutation: require the SDK only when opted in.
+        if args.language_agent:
+            ensure_cursor_sdk()
+
         # keep=True (do the work on the PR branch, commit it) only for a real
         # --open-pr run; --dry-run and classify-only leave the tree reset.
         # In keep mode, bail cheaply if this lang+tag was already proposed
@@ -1575,7 +1625,10 @@ def main() -> int:
         keep = args.open_pr and not args.dry_run
         result = existing_proposal(root, target) if keep else None
         if result is None:
-            result = propose(root, target, keep=keep, review_agent=args.review_agent)
+            result = propose(root, target, keep=keep, language_agent=args.language_agent,
+                             verbose=args.verbose, agent_timeout=args.agent_timeout,
+                             agent_token_cap=cap_or_none(args.agent_token_cap),
+                             agent_turn_cap=cap_or_none(args.agent_turn_cap))
 
         # Only a green, real update is worth a PR. Everything else (no-op,
         # no-tags, failed) is reported as-is for the workflow summary.

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -16,22 +16,15 @@
 # ///
 """Propose an upstream grammar update for a single language.
 
-This is the per-language driver behind the scheduled "propose grammar
-updates" GitHub Actions workflow. It wraps `scripts/update-grammar`,
-adding the orchestration that workflow needs:
+It wraps `scripts/update-grammar`, with the following orchestration:
 
   * resolve each grammar's latest *stable* release tag (never an in-flux
     upstream `master` commit),
-  * bump to it via `update-grammar --skip-release` (so nothing is ever
-    pushed to the downstream `semgrep-<lang>` repos),
+  * bump to it via `update-grammar --skip-release`,
   * regenerate the corpus snapshots a grammar bump invariably churns and
     re-run `test-lang` for an authoritative pass/fail,
-  * open exactly one PR in *this* repo when there's a real, green update,
+  * open one PR in *this* repo when there's a real, green update,
   * and clean up after itself so a failure never leaks into the next run.
-
-It deliberately reuses `update-grammar`'s language-discovery and
-version-file logic by importing it (see `_load_update_grammar`) rather
-than duplicating it.
 
 Modes:
   propose-grammar-update --list-languages [--json]
@@ -42,18 +35,11 @@ Modes:
   propose-grammar-update <language> [--open-pr] [--dry-run] [--language-agent]
       Bump <language> to its latest tag, regenerate snapshots, test, and
       emit a JSON result. With --open-pr, also create the PR; --dry-run
-      prints the would-be PR instead of pushing. --language-agent (explicit
-      opt-in) dispatches a Cursor agent to adapt tests on a test-lang
-      failure; without it a failing bump is simply reported as failed.
+      prints the would-be PR instead of pushing. --language-agent dispatches a Cursor
+      to fix the grammar on test-lang failure.
   propose-grammar-update <language> --release [--result FILE]
-      Downstream step: release the validated parser branch to
-      semgrep-<lang> via PR. semgrep-proprietary integration is left to
-      the existing Cursor workflow on that repo — not handled here.
-
-Wall-clock timeout / token cap / turn cap for the language agent are CLI flags
-(--agent-timeout / --agent-token-cap / --agent-turn-cap), not env vars — see
---help. The agent's model and credentials remain environment-based since
-they're read by the cursor_sdk itself, not this script.
+      Create a PR to semgrep-<lang>. semgrep-proprietary integration is left to
+      the existing Cursor workflow on that repo.
 
 Environment variables:
   GH_TOKEN / GITHUB_TOKEN   Required by every `gh` call (PR/label create,

--- a/scripts/test_cursor_agent_runner.py
+++ b/scripts/test_cursor_agent_runner.py
@@ -1,0 +1,423 @@
+"""Unit tests for scripts/cursor_agent_runner.py.
+
+A plain module (real .py extension, no top-level cursor_sdk import), so it's
+imported normally rather than via SourceFileLoader. cursor_sdk itself is
+never actually installed here: every test that reaches into run_language_agent
+injects a fake via sys.modules.
+"""
+
+from __future__ import annotations
+
+import argparse
+import threading
+import types
+import unittest
+import unittest.mock
+from pathlib import Path
+
+import cursor_agent_runner as car
+
+
+class TestParseDurationSeconds(unittest.TestCase):
+    def test_parses_seconds_minutes_hours_and_bare_numbers(self):
+        self.assertEqual(car.parse_duration_seconds("30s"), 30)
+        self.assertEqual(car.parse_duration_seconds("25m"), 25 * 60)
+        self.assertEqual(car.parse_duration_seconds("2h"), 2 * 3600)
+        self.assertEqual(car.parse_duration_seconds("3600"), 3600)
+
+    def test_invalid_value_raises_argument_type_error(self):
+        # A CLI `type=` function: bad input must be a clean argparse usage
+        # error, not a silently-substituted default.
+        for bad in ("", "invalid", "1x"):
+            with self.assertRaises(argparse.ArgumentTypeError):
+                car.parse_duration_seconds(bad)
+
+
+class TestCapOrNone(unittest.TestCase):
+    def test_positive_passes_through(self):
+        self.assertEqual(car.cap_or_none(50000), 50000)
+
+    def test_zero_and_negative_disable(self):
+        self.assertIsNone(car.cap_or_none(0))
+        self.assertIsNone(car.cap_or_none(-1))
+
+
+class TestLanguageAgentResult(unittest.TestCase):
+    def test_initialization_defaults(self):
+        result = car.LanguageAgentResult()
+        self.assertEqual(result.input_tokens, 0)
+        self.assertEqual(result.output_tokens, 0)
+        self.assertEqual(result.turns, 0)
+        self.assertIsNone(result.capped_reason)
+
+
+class TestEnsureCursorSdk(unittest.TestCase):
+    def test_exits_when_missing(self):
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": None}):
+            real_import = __import__
+
+            def fake_import(name, *args, **kwargs):
+                if name == "cursor_sdk" or name.startswith("cursor_sdk."):
+                    raise ImportError("nope")
+                return real_import(name, *args, **kwargs)
+
+            with unittest.mock.patch("builtins.__import__", side_effect=fake_import):
+                with self.assertRaises(SystemExit) as cm:
+                    car.ensure_cursor_sdk()
+        self.assertEqual(cm.exception.code, 1)
+
+    def test_ok_when_present(self):
+        mock_sdk = unittest.mock.MagicMock()
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_sdk}):
+            car.ensure_cursor_sdk()  # must not raise
+
+
+class TestRunLanguageAgentBasics(unittest.TestCase):
+    def test_dispatch_error_when_cursor_sdk_missing(self):
+        with unittest.mock.patch("builtins.__import__", side_effect=ImportError):
+            result = car.run_language_agent(Path("/tmp"), "prompt", label="php")
+        self.assertEqual(result.input_tokens, 0)
+        self.assertEqual(result.output_tokens, 0)
+        self.assertIsNone(result.capped_reason)
+
+    def test_sends_prompt_with_force_true(self):
+        mock_run = unittest.mock.MagicMock()
+        mock_run.status = "running"
+        mock_run_result = unittest.mock.MagicMock()
+        mock_run_result.status = "finished"
+        mock_run_result.usage = types.SimpleNamespace(input_tokens=75, output_tokens=25)
+        mock_run.events.return_value = iter([])
+        mock_run.wait.return_value = mock_run_result
+
+        mock_agent_instance = unittest.mock.MagicMock()
+        mock_agent_instance.send.return_value = mock_run
+        mock_cursor_sdk = unittest.mock.MagicMock()
+        mock_cursor_sdk.Agent.create.return_value.__enter__.return_value = mock_agent_instance
+        mock_cursor_sdk.Agent.create.return_value.__exit__.return_value = None
+
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}):
+            result = car.run_language_agent(Path("/tmp"), "fix it please", label="php")
+
+        self.assertEqual(result.input_tokens, 75)
+        self.assertEqual(result.output_tokens, 25)
+        self.assertIsNone(result.capped_reason)
+        mock_agent_instance.send.assert_called_once_with(
+            "fix it please", {"local": {"force": True}})
+
+
+class TestVerboseAndHeartbeat(unittest.TestCase):
+    """Always consumes events(); verbose only controls logging."""
+
+    def test_log_interaction_update_handles_known_kinds_without_raising(self):
+        cases = [
+            types.SimpleNamespace(type="tool-call-started", tool_call={"name": "edit"}),
+            types.SimpleNamespace(type="tool-call-completed", tool_call={"name": "edit"}),
+            types.SimpleNamespace(type="step-started", step_id="s1"),
+            types.SimpleNamespace(type="step-completed", step_id="s1", step_duration_ms=42),
+            types.SimpleNamespace(type="text-delta", text="hello"),
+            types.SimpleNamespace(type="thinking-delta", text="hmm"),
+            types.SimpleNamespace(type="shell-output-delta", event={"chunk": "out\n"}),
+            types.SimpleNamespace(type="token-delta", tokens=3),
+            types.SimpleNamespace(type="turn-ended", usage=None),
+            types.SimpleNamespace(type="unknown-thing"),
+        ]
+        for update in cases:
+            car._log_interaction_update(update)  # must not raise
+
+    def test_heartbeat_loop_logs_until_stopped(self):
+        stop = threading.Event()
+        calls = []
+        with unittest.mock.patch.object(car, "log", side_effect=calls.append):
+            t = threading.Thread(
+                target=car._heartbeat_loop, args=(stop, "php"), kwargs={"interval": 0.01},
+            )
+            t.start()
+            stop.wait(0.05)  # let a couple of intervals elapse
+            stop.set()
+            t.join(timeout=1)
+        self.assertGreater(len(calls), 0)
+        self.assertIn("php", calls[0])
+
+    def _fake_cursor_sdk(self, events, messages=None, *, run_status="running",
+                         wait_result=None):
+        """Build a fake cursor_sdk module wired to a canned event list.
+
+        If `messages` is given and `events` is empty, wrap each message as an
+        sdk_message event (run_language_agent always consumes events()).
+        """
+        if not events and messages is not None:
+            events = [
+                types.SimpleNamespace(
+                    kind="sdk_message", sdk_message=m, interaction_update=None)
+                for m in messages
+            ]
+        mock_run = unittest.mock.MagicMock()
+        mock_run.status = run_status
+        mock_run.usage = None
+        mock_run.events.return_value = iter(events)
+        mock_run.wait.return_value = (
+            wait_result if wait_result is not None
+            else types.SimpleNamespace(usage=None, status="finished", error=None)
+        )
+
+        mock_agent_instance = unittest.mock.MagicMock()
+        mock_agent_instance.send.return_value = mock_run
+
+        mock_cursor_sdk = unittest.mock.MagicMock()
+        mock_cursor_sdk.Agent.create.return_value.__enter__.return_value = (
+            mock_agent_instance)
+        mock_cursor_sdk.Agent.create.return_value.__exit__.return_value = None
+        mock_cursor_sdk._agent = mock_agent_instance
+        mock_cursor_sdk._run = mock_run
+        return mock_cursor_sdk
+
+    def test_verbose_mode_uses_events_and_logs_interaction_updates(self):
+        assistant_msg = types.SimpleNamespace(type="assistant", usage=None)
+        tool_update = types.SimpleNamespace(type="tool-call-started", tool_call={"name": "edit"})
+        events = [
+            types.SimpleNamespace(kind="interaction_update", interaction_update=tool_update,
+                                  sdk_message=None),
+            types.SimpleNamespace(kind="sdk_message", sdk_message=assistant_msg,
+                                  interaction_update=None),
+        ]
+        mock_cursor_sdk = self._fake_cursor_sdk(events)
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.object(car, "_log_agent_message") as log_msg, \
+             unittest.mock.patch.object(car, "_log_interaction_update") as log_update, \
+             unittest.mock.patch.object(car, "_heartbeat_loop") as heartbeat:
+            car.run_language_agent(Path("/tmp"), "prompt", label="php", verbose=True)
+        log_update.assert_called_once_with(tool_update)
+        log_msg.assert_called_once_with(assistant_msg)
+        heartbeat.assert_not_called()
+
+    def test_non_verbose_mode_skips_message_logging_and_starts_heartbeat(self):
+        usage_msg = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=10, output_tokens=5))
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=[usage_msg])
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.object(car, "_log_agent_message") as log_msg, \
+             unittest.mock.patch.object(car, "_log_interaction_update") as log_update, \
+             unittest.mock.patch.object(car, "_heartbeat_loop") as heartbeat:
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", verbose=False)
+        log_msg.assert_not_called()
+        log_update.assert_not_called()
+        heartbeat.assert_called_once()
+        self.assertEqual(result.input_tokens, 10)
+        self.assertEqual(result.output_tokens, 5)
+        self.assertEqual(result.turns, 1)
+
+    def test_token_delta_trips_cap_mid_turn(self):
+        """token-delta updates should cancel before a turn-end usage message."""
+        deltas = [
+            types.SimpleNamespace(
+                kind="interaction_update",
+                interaction_update=types.SimpleNamespace(type="token-delta", tokens=400),
+                sdk_message=None),
+            types.SimpleNamespace(
+                kind="interaction_update",
+                interaction_update=types.SimpleNamespace(type="token-delta", tokens=200),
+                sdk_message=None),
+            types.SimpleNamespace(
+                kind="sdk_message",
+                sdk_message=types.SimpleNamespace(
+                    type="usage",
+                    usage=types.SimpleNamespace(input_tokens=9999, output_tokens=9999)),
+                interaction_update=None),
+        ]
+        mock_cursor_sdk = self._fake_cursor_sdk(deltas)
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.object(car, "log") as log_fn:
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", token_cap=500)
+        self.assertEqual(result.capped_reason, "token_cap")
+        self.assertEqual(result.output_tokens, 600)
+        mock_cursor_sdk._run.cancel.assert_called_once()
+        self.assertTrue(any("token cap" in str(c) for c in log_fn.call_args_list))
+
+    def test_wall_clock_timeout_logs_to_stderr(self):
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=[])
+
+        class ImmediateTimer:
+            def __init__(self, interval, function):
+                self.function = function
+            def start(self):
+                self.function()
+            def cancel(self):
+                pass
+
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.object(car.threading, "Timer", ImmediateTimer), \
+             unittest.mock.patch.object(car, "log") as log_fn:
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", timeout_seconds=1)
+        self.assertEqual(result.capped_reason, "wall_clock_timeout")
+        self.assertTrue(any("wall-clock timeout" in str(c) for c in log_fn.call_args_list))
+
+    def test_model_defaults_to_auto_when_unset(self):
+        # SDK requires a non-empty model; default is "auto".
+        import os
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=[])
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.dict("os.environ", {}, clear=False):
+            os.environ.pop("CURSOR_MODEL", None)
+            car.run_language_agent(Path("/tmp"), "prompt", label="php")
+        self.assertEqual(mock_cursor_sdk.Agent.create.call_args.kwargs["model"], "auto")
+
+    def test_model_env_override_respected(self):
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=[])
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.dict("os.environ", {"CURSOR_MODEL": "gpt-5.3-codex"}):
+            car.run_language_agent(Path("/tmp"), "prompt", label="php")
+        self.assertEqual(
+            mock_cursor_sdk.Agent.create.call_args.kwargs["model"], "gpt-5.3-codex")
+
+    def test_token_cap_cancels_run_and_stops_processing_further_messages(self):
+        under_cap = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=5, output_tokens=5))
+        over_cap = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=100, output_tokens=0))
+        # Past the cap — must not be applied if cancel worked.
+        after_cap = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=999, output_tokens=999))
+        mock_cursor_sdk = self._fake_cursor_sdk(
+            [], messages=[under_cap, over_cap, after_cap])
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}):
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", token_cap=50)
+        self.assertEqual(result.capped_reason, "token_cap")
+        self.assertEqual(result.input_tokens, 100)
+        self.assertEqual(result.output_tokens, 0)
+        mock_cursor_sdk._run.cancel.assert_called_once()
+
+    def test_turn_cap_cancels_after_n_usage_messages(self):
+        """Each usage message is one completed turn; cancel at the Nth."""
+        turn1 = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=10, output_tokens=1))
+        turn2 = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=20, output_tokens=2))
+        turn3 = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=999, output_tokens=999))
+        mock_cursor_sdk = self._fake_cursor_sdk(
+            [], messages=[turn1, turn2, turn3])
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.object(car, "log") as log_fn:
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", turn_cap=2, token_cap=None)
+        self.assertEqual(result.capped_reason, "turn_cap")
+        self.assertEqual(result.turns, 2)
+        self.assertEqual(result.input_tokens, 20)
+        self.assertEqual(result.output_tokens, 2)
+        mock_cursor_sdk._run.cancel.assert_called_once()
+        self.assertTrue(any("turn cap" in str(c) for c in log_fn.call_args_list))
+
+    def test_turn_cap_disabled_allows_many_turns(self):
+        msgs = [
+            types.SimpleNamespace(
+                type="usage",
+                usage=types.SimpleNamespace(input_tokens=i, output_tokens=0))
+            for i in range(1, 6)
+        ]
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=msgs)
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}):
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", turn_cap=None, token_cap=None)
+        self.assertIsNone(result.capped_reason)
+        self.assertEqual(result.turns, 5)
+        mock_cursor_sdk._run.cancel.assert_not_called()
+
+    def test_wait_usage_does_not_overwrite_tokens_after_token_cap(self):
+        """Regression: run.wait() used to clobber stream usage after a cap."""
+        over_cap = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=100, output_tokens=7))
+        wait_result = types.SimpleNamespace(
+            usage=types.SimpleNamespace(input_tokens=1, output_tokens=1),
+            status="cancelled", error=None)
+        mock_cursor_sdk = self._fake_cursor_sdk(
+            [], messages=[over_cap], wait_result=wait_result)
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}):
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", token_cap=50)
+        self.assertEqual(result.capped_reason, "token_cap")
+        self.assertEqual(result.input_tokens, 100)
+        self.assertEqual(result.output_tokens, 7)
+
+    def test_late_wall_clock_timer_does_not_override_token_cap_reason(self):
+        """Regression: the wall-clock timer used to only get cancelled AFTER
+        run.wait() returned, so a timer racing in during that wait could
+        clobber an already-set token_cap reason with wall_clock_timeout."""
+        over_cap = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=100, output_tokens=0))
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=[over_cap])
+
+        fake_timer = {}
+
+        class FakeTimer:
+            def __init__(self, interval, function):
+                self.function = function
+                self.cancelled = False
+                fake_timer["instance"] = self
+
+            def start(self):
+                pass
+
+            def cancel(self):
+                self.cancelled = True
+
+            def fire(self):
+                # Mirrors real threading.Timer: cancel() before firing is a no-op.
+                if not self.cancelled:
+                    self.function()
+
+        def wait_with_late_timer_fire():
+            # Simulate the timer's callback racing in while run.wait() blocks.
+            fake_timer["instance"].fire()
+            return types.SimpleNamespace(usage=None, status="finished", error=None)
+
+        mock_cursor_sdk._run.wait.side_effect = wait_with_late_timer_fire
+
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.object(car.threading, "Timer", FakeTimer):
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", token_cap=50)
+
+        self.assertEqual(result.capped_reason, "token_cap")
+        self.assertTrue(fake_timer["instance"].cancelled)
+
+    def test_token_cap_none_disables_check(self):
+        usage_msg = types.SimpleNamespace(
+            type="usage",
+            usage=types.SimpleNamespace(input_tokens=10_000_000, output_tokens=0))
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=[usage_msg])
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}):
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", token_cap=None)
+        self.assertIsNone(result.capped_reason)
+        mock_cursor_sdk._run.cancel.assert_not_called()
+
+    def test_cancel_skipped_when_run_already_terminal(self):
+        over_cap = types.SimpleNamespace(
+            type="usage", usage=types.SimpleNamespace(input_tokens=100, output_tokens=0))
+        mock_cursor_sdk = self._fake_cursor_sdk(
+            [], messages=[over_cap], run_status="finished")
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}):
+            result = car.run_language_agent(
+                Path("/tmp"), "prompt", label="php", token_cap=50)
+        self.assertEqual(result.capped_reason, "token_cap")
+        mock_cursor_sdk._run.cancel.assert_not_called()
+
+    def test_structured_run_error_is_logged(self):
+        err = types.SimpleNamespace(message="bridge died", code="internal")
+        wait_result = types.SimpleNamespace(usage=None, status="error", error=err)
+        mock_cursor_sdk = self._fake_cursor_sdk([], messages=[], wait_result=wait_result)
+        with unittest.mock.patch.dict("sys.modules", {"cursor_sdk": mock_cursor_sdk}), \
+             unittest.mock.patch.object(car, "log") as log_fn:
+            car.run_language_agent(Path("/tmp"), "prompt", label="php")
+        self.assertTrue(any(
+            "bridge died" in str(c) and "internal" in str(c)
+            for c in log_fn.call_args_list
+        ))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/scripts/test_cursor_agent_runner.py
+++ b/scripts/test_cursor_agent_runner.py
@@ -343,9 +343,8 @@ class TestVerboseAndHeartbeat(unittest.TestCase):
         self.assertEqual(result.output_tokens, 7)
 
     def test_late_wall_clock_timer_does_not_override_token_cap_reason(self):
-        """Regression: the wall-clock timer used to only get cancelled AFTER
-        run.wait() returned, so a timer racing in during that wait could
-        clobber an already-set token_cap reason with wall_clock_timeout."""
+        """Regression: a timer callback already in flight when token_cap trips
+        must not clobber capped_reason or double-cancel the run."""
         over_cap = types.SimpleNamespace(
             type="usage", usage=types.SimpleNamespace(input_tokens=100, output_tokens=0))
         mock_cursor_sdk = self._fake_cursor_sdk([], messages=[over_cap])
@@ -365,9 +364,8 @@ class TestVerboseAndHeartbeat(unittest.TestCase):
                 self.cancelled = True
 
             def fire(self):
-                # Mirrors real threading.Timer: cancel() before firing is a no-op.
-                if not self.cancelled:
-                    self.function()
+                # Callback already running: Timer.cancel() does not stop it.
+                self.function()
 
         def wait_with_late_timer_fire():
             # Simulate the timer's callback racing in while run.wait() blocks.
@@ -383,6 +381,28 @@ class TestVerboseAndHeartbeat(unittest.TestCase):
 
         self.assertEqual(result.capped_reason, "token_cap")
         self.assertTrue(fake_timer["instance"].cancelled)
+        mock_cursor_sdk._run.cancel.assert_called_once()
+
+    def test_claim_cap_first_writer_wins_under_contention(self):
+        result = car.LanguageAgentResult()
+        lock = threading.Lock()
+        winners = []
+
+        def claim(reason):
+            if car._claim_cap(result, lock, reason, f"msg-{reason}"):
+                winners.append(reason)
+
+        threads = [
+            threading.Thread(target=claim, args=("token_cap",)),
+            threading.Thread(target=claim, args=("wall_clock_timeout",)),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        self.assertEqual(len(winners), 1)
+        self.assertEqual(result.capped_reason, winners[0])
 
     def test_token_cap_none_disables_check(self):
         usage_msg = types.SimpleNamespace(

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -1,3 +1,16 @@
+#!/usr/bin/env -S uv run --script
+# /// script
+# requires-python = ">=3.11"
+# dependencies = [
+#     # Keep in sync with scripts/propose-grammar-update.
+#     "cursor-sdk==1.0.24",
+# ]
+#
+# [tool.uv]
+# # Keep in sync with scripts/propose-grammar-update.
+# exclude-newer = "1 week"
+# exclude-newer-package = { cursor-sdk = false }
+# ///
 """Unit tests for scripts/propose-grammar-update.
 
 Mirrors scripts/test_update_grammar.py: load the extensionless driver via
@@ -10,6 +23,7 @@ by the integration run in the workflow.
 from __future__ import annotations
 
 import contextlib
+import io
 import json
 import sys
 import unittest
@@ -18,6 +32,8 @@ from importlib.machinery import SourceFileLoader
 from importlib.util import module_from_spec, spec_from_loader
 from pathlib import Path
 from tempfile import TemporaryDirectory
+
+import cursor_agent_runner as car
 
 SCRIPT_PATH = Path(__file__).resolve().parent / "propose-grammar-update"
 
@@ -199,6 +215,28 @@ class TestPrShaping(unittest.TestCase):
         body = pg.pr_body(result, "https://github.com/tree-sitter/tree-sitter-php.git")
         self.assertIn("_No corpus snapshot changes._", body)
 
+    def test_open_pr_captures_created_pr_url(self):
+        import subprocess as sp
+
+        target = pg.Target(
+            lang=pg.LangAndWrapper("python", "python"), submodule=Path("/tmp/s"),
+            tag="v0.25.0", url="https://github.com/tree-sitter/tree-sitter-python.git",
+        )
+        result = pg.Result(language="python", new_tag="v0.25.0",
+                           branch="grammar-update/python/v0.25.0")
+        created = sp.CompletedProcess(
+            [], 0,
+            stdout="Creating pull request...\n"
+                   "https://github.com/semgrep/ocaml-tree-sitter-semgrep/pull/123\n",
+            stderr="",
+        )
+        with unittest.mock.patch.object(pg, "run_quiet"), \
+             unittest.mock.patch.object(pg, "base_branch", return_value="main"), \
+             unittest.mock.patch("subprocess.run", return_value=created):
+            out = pg.open_pr(Path("/tmp"), target, result, dry_run=False)
+        self.assertEqual(
+            out.pr_url, "https://github.com/semgrep/ocaml-tree-sitter-semgrep/pull/123")
+
 
 ###############################################################################
 # Downstream: release dialects + agent prompt #
@@ -241,18 +279,18 @@ class TestProposeFailurePath(unittest.TestCase):
         ts_version="0.26.3", url="https://x/y.git", tag="v0.24.2",
     )
 
-    def _run(self, test_returncodes, review_agent=True, bump_rc=0,
+    def _run(self, test_returncodes, language_agent=True, bump_rc=0,
              shas=("OLD", "NEW")):
         """Run propose() with mocked internals; test_returncodes drives the
         test-lang result(s) in sequence (first run, then post-agent re-run).
-        Returns (result, review_agent_mock)."""
+        Returns (result, language_agent_mock)."""
         import subprocess as sp
         calls = iter(test_returncodes)
 
         def fake_test(_lang, _root):
             return sp.CompletedProcess([], next(calls), stdout="log", stderr="")
 
-        agent = unittest.mock.Mock(return_value=None)
+        agent = unittest.mock.Mock(return_value=car.LanguageAgentResult())
         with unittest.mock.patch.multiple(
             pg,
             run_update_grammar=lambda *a, **k: sp.CompletedProcess(
@@ -261,11 +299,11 @@ class TestProposeFailurePath(unittest.TestCase):
             regenerate_snapshots=lambda *a, **k: None,
             corpus_diff=lambda *a, **k: "",
             run_test_lang=fake_test,
-            run_review_agent=agent,
+            run_language_agent=agent,
             reset_language_state=lambda *a, **k: None,
         ):
             result = pg.propose(Path("."), self.TARGET, keep=False,
-                                review_agent=review_agent)
+                                language_agent=language_agent)
         return result, agent
 
     def test_failure_returns_failed_not_nameerror(self):
@@ -275,6 +313,15 @@ class TestProposeFailurePath(unittest.TestCase):
         self.assertEqual(r.status, pg.STATUS_FAILED)
         self.assertFalse(r.tests_adapted)
         agent.assert_called_once()
+
+    def test_agent_called_with_grammar_specific_prompt_and_label(self):
+        # cursor_agent_runner knows nothing about languages/tags: propose()
+        # must build the prompt itself and pass the language as `label`.
+        _r, agent = self._run([1, 1])
+        _root, prompt = agent.call_args.args
+        self.assertIn("test-lang php", prompt)
+        self.assertIn("v0.24.2", prompt)
+        self.assertEqual(agent.call_args.kwargs["label"], "php")
 
     def test_agent_recovers_sets_tests_adapted(self):
         # test-lang fails, agent adapts, re-test passes -> updated + flag.
@@ -289,9 +336,9 @@ class TestProposeFailurePath(unittest.TestCase):
         agent.assert_not_called()
 
     def test_agent_not_dispatched_unless_opted_in(self):
-        # The Cursor dispatch is an explicit opt-in: with review_agent=False
+        # The Cursor dispatch is an explicit opt-in: with language_agent=False
         # a failing bump is reported failed and the agent is NEVER invoked.
-        r, agent = self._run([1], review_agent=False)
+        r, agent = self._run([1], language_agent=False)
         self.assertEqual(r.status, pg.STATUS_FAILED)
         self.assertIn("not enabled", r.detail)
         agent.assert_not_called()
@@ -323,7 +370,7 @@ class TestProposeFailurePath(unittest.TestCase):
             submodule_head=unittest.mock.Mock(return_value="OLD"),
             reset_language_state=lambda *a, **k: None,
         ):
-            r = pg.propose(Path("."), self.TARGET, keep=False, review_agent=False)
+            r = pg.propose(Path("."), self.TARGET, keep=False, language_agent=False)
         self.assertEqual(r.status, pg.STATUS_FAILED)
         self.assertIn("CalledProcessError", r.detail)
 
@@ -412,7 +459,7 @@ class TestMainFailedJson(unittest.TestCase):
         args = SimpleNamespace(
             list_languages=False, summarize=None, language="php",
             resolve_tag_only=False, release=False, open_pr=False, dry_run=False,
-            review_agent=False, result=None, json=False, updatable_only=False,
+            language_agent=False, result=None, json=False, updatable_only=False,
         )
         cms = [
             unittest.mock.patch.object(pg, "parse_args", return_value=args),
@@ -497,9 +544,9 @@ class TestUpToDateFilter(unittest.TestCase):
             self.assertIsNone(pg.is_up_to_date(Path("."), self.LANG))
 
 
-class TestReviewAgent(unittest.TestCase):
+class TestLanguageAgent(unittest.TestCase):
     def test_prompt_drives_fix_semgrep_grammar_skill(self):
-        p = pg.review_agent_prompt(
+        p = pg.language_agent_prompt(
             pg.LangAndWrapper("php", "php"), "v0.24.2", "FAIL log here"
         )
         # Must invoke Marc-André's skill (not hand-rolled fix logic), pass the
@@ -531,6 +578,38 @@ class TestReviewAgent(unittest.TestCase):
         self.assertNotIn("agent adapted", pg.pr_body(base, url).lower())
         adapted = dataclasses.replace(base, tests_adapted=True)
         self.assertIn("agent adapted", pg.pr_body(adapted, url).lower())
+
+class TestAgentCliArgs(unittest.TestCase):
+    """--agent-timeout/--agent-token-cap/--agent-turn-cap: the CLI surface a
+    manual GitHub Actions dispatch can set (see propose-grammar-updates.yml).
+    """
+
+    def test_defaults_match_module_defaults(self):
+        args = pg.parse_args(["php", "--open-pr"])
+        self.assertEqual(args.agent_timeout, car.parse_duration_seconds(car.DEFAULT_AGENT_TIMEOUT))
+        self.assertEqual(args.agent_token_cap, car.DEFAULT_AGENT_TOKEN_CAP)
+        self.assertEqual(args.agent_turn_cap, car.DEFAULT_AGENT_TURN_CAP)
+
+    def test_overrides_are_parsed(self):
+        args = pg.parse_args([
+            "php", "--open-pr", "--agent-timeout", "5m",
+            "--agent-token-cap", "1000", "--agent-turn-cap", "3",
+        ])
+        self.assertEqual(args.agent_timeout, 300)
+        self.assertEqual(args.agent_token_cap, 1000)
+        self.assertEqual(args.agent_turn_cap, 3)
+
+    def test_zero_caps_disable_via_cap_or_none(self):
+        args = pg.parse_args([
+            "php", "--open-pr", "--agent-token-cap", "0", "--agent-turn-cap", "0",
+        ])
+        self.assertIsNone(car.cap_or_none(args.agent_token_cap))
+        self.assertIsNone(car.cap_or_none(args.agent_turn_cap))
+
+    def test_invalid_timeout_is_a_clean_cli_error(self):
+        with contextlib.redirect_stderr(io.StringIO()):
+            with self.assertRaises(SystemExit):
+                pg.parse_args(["php", "--open-pr", "--agent-timeout", "banana"])
 
 
 ###############################################################################


### PR DESCRIPTION
## Summary

- Replace Cursor CLI review-agent dispatch with `cursor-sdk` local agents (`1.0.24`), managed via uv PEP 723 deps.
- Add token/wall-clock caps, structured run-error logging, `--verbose` event stream, and fail-fast SDK import only when `--review-agent` is set (before mutating the repo).
- Wire workflows/Makefile to `uv run`; drop the pytest-on-PATH branch in `make test-python`.

This closes LANG-577.

## Test plan

- [x] `uv run --script scripts/test_propose_grammar_update.py`
- [x] `make test-python` (with uv installed)
- [ ] Manual/workflow dry-run with `run_review_agent=true` on a known failing bump