### PR TITLE
fix: report integrate failures in Slack status table

### DIFF
--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -236,33 +236,49 @@ jobs:
       matrix:
         language: ${{ fromJSON(needs.enumerate.outputs.languages) }}
     steps:
-      - name: Inject failure (test mode)
-        if: inputs.inject_failure == 'integrate'
-        run: |
-          echo "::error::Failure injected via the inject_failure input (test mode)"
-          exit 1
       - uses: step-security/harden-runner@9af89fc71515a100421586dfdb3dc9c984fbf411 # v2.19.4
         with:
           egress-policy: audit
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
+      # Download outside the workspace: actions/checkout wipes GITHUB_WORKSPACE,
+      # which previously deleted the propose artifact and made --result miss
+      # the file (FileNotFoundError) after a successful gate check.
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: result-${{ matrix.language }}
-          path: result
+          path: ${{ runner.temp }}/propose-result
         continue-on-error: true   # no artifact => this language wasn't proposed
       - name: Skip unless this language was updated
         id: gate
+        env:
+          PROPOSE_RESULT: ${{ runner.temp }}/propose-result/result-${{ matrix.language }}.json
         run: |
           # Bad/empty JSON => skip (don't fail the step).
-          f="result/result-${{ matrix.language }}.json"
           go=false
-          if [ -f "$f" ]; then
-            status=$(python -c "import json,sys; print(json.load(open(sys.argv[1])).get('status') or '')" "$f" 2>/dev/null) || status=""
+          if [ -f "$PROPOSE_RESULT" ]; then
+            status=$(python -c "import json,sys; print(json.load(open(sys.argv[1])).get('status') or '')" "$PROPOSE_RESULT" 2>/dev/null) || status=""
             [ "$status" = "updated" ] && go=true
           fi
           echo "go=$go" >> "$GITHUB_OUTPUT"
+      # Seed outside the workspace so checkout can't wipe it; release tees
+      # over this file, and on any later failure we flip `updated` → `failed`
+      # before uploading (overwrites the propose artifact for Slack/summary).
+      - if: steps.gate.outputs.go == 'true'
+        name: Seed result for reporting
+        env:
+          PROPOSE_RESULT: ${{ runner.temp }}/propose-result/result-${{ matrix.language }}.json
+          OUT_RESULT: ${{ runner.temp }}/out-result/result-${{ matrix.language }}.json
+        run: |
+          mkdir -p "$(dirname "$OUT_RESULT")"
+          cp "$PROPOSE_RESULT" "$OUT_RESULT"
+      # After seed so Record-integrate-failure can flip the table row too.
+      - name: Inject failure (test mode)
+        if: inputs.inject_failure == 'integrate'
+        run: |
+          echo "::error::Failure injected via the inject_failure input (test mode)"
+          exit 1
       - if: steps.gate.outputs.go == 'true'
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
         with:
@@ -309,18 +325,59 @@ jobs:
           # creds than GITHUB_TOKEN.
           GH_TOKEN: ${{ secrets.SEMGREP_LANG_PAT }}
           GITHUB_TOKEN: ${{ secrets.SEMGREP_LANG_PAT }}
+          PROPOSE_RESULT: ${{ runner.temp }}/propose-result/result-${{ matrix.language }}.json
+          OUT_RESULT: ${{ runner.temp }}/out-result/result-${{ matrix.language }}.json
         run: |
           # Make git's HTTPS pushes (lang/release clones + pushes
           # semgrep-<lang> via the insteadOf rewrite) authenticate with the
           # PAT. Without this, `git push` has no credential helper and the
           # downstream release fails.
           gh auth setup-git
+          # bash -e omits pipefail; without it `| tee` hides script failures.
+          set -o pipefail
           # opam exec: same reason as the propose job — the nested
           # lang/release -> make gen-c needs `ocaml-tree-sitter` on PATH.
           # --result: release the exact tag/branch the propose job validated
           # (from its artifact), never a live re-resolved one.
+          # stdout Result JSON overwrites the seeded propose row so success
+          # keeps `updated` and failure becomes `failed` for Slack/summary.
           opam exec -- uv run --script scripts/propose-grammar-update "${{ matrix.language }}" --release \
-            --result "result/result-${{ matrix.language }}.json"
+            --result "$PROPOSE_RESULT" \
+            | tee "$OUT_RESULT"
+      # If setup/build failed before release could report, flip the seeded
+      # propose `updated` row to failed so the Slack table isn't a lie.
+      - name: Record integrate failure
+        if: always() && steps.gate.outputs.go == 'true' && failure()
+        env:
+          OUT_RESULT: ${{ runner.temp }}/out-result/result-${{ matrix.language }}.json
+        run: |
+          if [ -f scripts/propose-grammar-update ]; then
+            python scripts/propose-grammar-update --mark-failed "$OUT_RESULT" \
+              --failed-detail "integrate failed (see job log)"
+          else
+            # checkout never landed; flip the seeded propose row in-place
+            python -c "
+          import json, os
+          from pathlib import Path
+          p = Path(os.environ['OUT_RESULT'])
+          d = json.loads(p.read_text()) if p.is_file() and p.stat().st_size else {}
+          if not (isinstance(d, dict) and d.get('status') == 'failed' and d.get('detail')):
+              if not isinstance(d, dict):
+                  d = {}
+              d.setdefault('language', '${{ matrix.language }}')
+              d['status'] = 'failed'
+              d['detail'] = 'integrate failed (see job log)'
+              p.parent.mkdir(parents=True, exist_ok=True)
+              p.write_text(json.dumps(d) + '\n')
+          "
+          fi
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
+        if: always() && steps.gate.outputs.go == 'true'
+        with:
+          name: result-${{ matrix.language }}
+          path: ${{ runner.temp }}/out-result/result-${{ matrix.language }}.json
+          overwrite: true
+          if-no-files-found: ignore
 
   summary:
     name: Summary
@@ -348,11 +405,11 @@ jobs:
   # Slack notification (LANG-604): pages #support-engine when any job fails,
   # posts a success note (with PR links) when update PRs were opened, and a
   # quiet "nothing to do" heartbeat otherwise. Job-level results
-  # are the authoritative failure signal: propose-grammar-update exits
-  # non-zero on a failed bump/test, and this also catches failures the
-  # script can't see from inside (build breakage, timeouts, crashes). The
-  # message carries only job statuses, PR links and the status table + a run
-  # link — never grammar source or logs.
+  # are the authoritative failure signal for the alert header; the per-language
+  # table comes from result artifacts, which integrate overwrites on release
+  # failure so a green propose + failed release shows as `failed`, not
+  # leftover `updated`. The message carries only job statuses, PR links and
+  # the status table + a run link — never grammar source or logs.
   notify:
     name: Notify Slack
     needs: [enumerate, propose, integrate]

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -398,14 +398,11 @@ jobs:
       - name: Render summary
         run: uv run --script scripts/propose-grammar-update --summarize results >> "$GITHUB_STEP_SUMMARY"
 
-  # Slack notification (LANG-604): pages #support-engine when any job fails,
-  # posts a success note (with PR links) when update PRs were opened, and a
-  # quiet "nothing to do" heartbeat otherwise. Job-level results
-  # are the authoritative failure signal for the alert header; the per-language
-  # table comes from result artifacts, which integrate overwrites on release
-  # failure so a green propose + failed release shows as `failed`, not
-  # leftover `updated`. The message carries only job statuses, PR links and
-  # the status table + a run link — never grammar source or logs.
+  # Slack notification (LANG-604): pages #support-engine on failure, notes
+  # opened PRs on success, else a quiet heartbeat. Status table reads result
+  # artifacts, which integrate overwrites on release failure so a green
+  # propose doesn't leave a stale `updated` row. Never includes grammar
+  # source or logs.
   notify:
     name: Notify Slack
     needs: [enumerate, propose, integrate]

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -242,9 +242,8 @@ jobs:
       - uses: actions/setup-python@a309ff8b426b58ec0e2a45f0f869d46889d02405 # v6.2.0
         with:
           python-version: '3.11'
-      # Download outside the workspace: actions/checkout wipes GITHUB_WORKSPACE,
-      # which previously deleted the propose artifact and made --result miss
-      # the file (FileNotFoundError) after a successful gate check.
+      # Download to $RUNNER_TEMP: checkout wipes the workspace and used to
+      # delete the propose artifact (FileNotFoundError on --result).
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: result-${{ matrix.language }}
@@ -262,9 +261,7 @@ jobs:
             [ "$status" = "updated" ] && go=true
           fi
           echo "go=$go" >> "$GITHUB_OUTPUT"
-      # Seed outside the workspace so checkout can't wipe it; release tees
-      # over this file, and on any later failure we flip `updated` → `failed`
-      # before uploading (overwrites the propose artifact for Slack/summary).
+      # Seed for Slack: release tees over this; on failure we flip updated→failed.
       - if: steps.gate.outputs.go == 'true'
         name: Seed result for reporting
         env:
@@ -337,40 +334,31 @@ jobs:
           set -o pipefail
           # opam exec: same reason as the propose job — the nested
           # lang/release -> make gen-c needs `ocaml-tree-sitter` on PATH.
-          # --result: release the exact tag/branch the propose job validated
-          # (from its artifact), never a live re-resolved one.
-          # stdout Result JSON overwrites the seeded propose row so success
-          # keeps `updated` and failure becomes `failed` for Slack/summary.
+          # --result: exact tag/branch propose validated. stdout Result JSON
+          # overwrites the seeded row (updated on success, failed on release fail).
           opam exec -- uv run --script scripts/propose-grammar-update "${{ matrix.language }}" --release \
             --result "$PROPOSE_RESULT" \
             | tee "$OUT_RESULT"
-      # If setup/build failed before release could report, flip the seeded
-      # propose `updated` row to failed so the Slack table isn't a lie.
+      # Setup/build failure before release: flip seeded updated → failed for Slack.
       - name: Record integrate failure
         if: always() && steps.gate.outputs.go == 'true' && failure()
         env:
           OUT_RESULT: ${{ runner.temp }}/out-result/result-${{ matrix.language }}.json
         run: |
-          if [ -f scripts/propose-grammar-update ]; then
-            python scripts/propose-grammar-update --mark-failed "$OUT_RESULT" \
-              --failed-detail "integrate failed (see job log)"
-          else
-            # checkout never landed; flip the seeded propose row in-place
-            python -c "
+          python -c "
           import json, os
           from pathlib import Path
           p = Path(os.environ['OUT_RESULT'])
           d = json.loads(p.read_text()) if p.is_file() and p.stat().st_size else {}
-          if not (isinstance(d, dict) and d.get('status') == 'failed' and d.get('detail')):
-              if not isinstance(d, dict):
-                  d = {}
+          if not isinstance(d, dict):
+              d = {}
+          if d.get('status') != 'failed':
               d.setdefault('language', '${{ matrix.language }}')
               d['status'] = 'failed'
               d['detail'] = 'integrate failed (see job log)'
               p.parent.mkdir(parents=True, exist_ok=True)
               p.write_text(json.dumps(d) + '\n')
           "
-          fi
       - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         if: always() && steps.gate.outputs.go == 'true'
         with:

--- a/.github/workflows/propose-grammar-updates.yml
+++ b/.github/workflows/propose-grammar-updates.yml
@@ -54,6 +54,9 @@ on:
       notify_channel:
         description: "Test mode: Slack channel or member ID (e.g. U0123456789 for a DM) to send notifications to instead of #support-engine."
         required: false
+      base_branch:
+        description: "Test mode: fork the grammar-update branch from this branch instead of main, so a fix on a feature branch can be validated before merging. Blank = main."
+        required: false
 
 permissions:
   contents: write         # push grammar-update/* branches in THIS repo
@@ -189,9 +192,14 @@ jobs:
           AGENT_TOKEN_CAP: ${{ inputs.agent_token_cap }}
           AGENT_TURN_CAP: ${{ inputs.agent_turn_cap }}
           DRY_RUN: ${{ inputs.dry_run }}
+          INPUT_BASE_BRANCH: ${{ inputs.base_branch }}
         run: |
           # bash -e omits pipefail; without it `| tee` hides script failures.
           set -o pipefail
+          # Blank (the default) leaves GRAMMAR_BASE_BRANCH unset so the
+          # script's own "main" default applies — an empty env var would
+          # fail its validation instead of falling back.
+          if [ -n "$INPUT_BASE_BRANCH" ]; then export GRAMMAR_BASE_BRANCH="$INPUT_BASE_BRANCH"; fi
           # opam exec puts the switch bin on PATH so the nested test-lang ->
           # make gen-c can find the `ocaml-tree-sitter` binary (installed by
           # `make install`). Without it: "ocaml-tree-sitter: command not found".

--- a/lang/release
+++ b/lang/release
@@ -1,8 +1,7 @@
 #! /usr/bin/env bash
 #
 # Place the generated files into their own repo, to be used by an external
-# repo as a submodule. Rebuilds the extended semgrep-<lang> grammar first
-# (same prerequisite as test-lang) so gen-c has grammar.json to import.
+# repo as a submodule.
 #
 set -eu -o pipefail
 
@@ -10,10 +9,9 @@ prog_name=$(basename "$0")
 
 usage() {
   cat <<EOF
-Publish generated code to an external repository for a specific language.
+** This may be done only after running 'test-lang'. **
 
-Builds the extended semgrep-LANG grammar (prep + tree-sitter generate) so
-gen-c can import grammar.json, then publishes ocaml-src to semgrep-LANG.
+Publish generated code to an external repository for a specific language.
 
 Sublanguages defined in the same tree-sitter-LANG project are considered
 different at this stage, e.g. 'tree-sitter-typescript' provides grammars
@@ -224,22 +222,6 @@ if [[ "$make_new" != true ]]; then
 else
   branch="${branch_arg:-main}"
 fi
-
-# gen-c needs grammar.json from the extended grammar; build it first (as
-# test-lang does). Dialects share a wrapper project (tsx → semgrep-typescript).
-case "$lang" in
-  typescript|tsx) wrapper=typescript ;;
-  php|php-only) wrapper=php ;;
-  apex) wrapper=sfapex ;;
-  *) wrapper=$lang ;;
-esac
-ext_proj="semgrep-grammars/src/semgrep-$wrapper"
-if [[ ! -d "$ext_proj" ]]; then
-  error "Missing extended grammar project $ext_proj"
-fi
-echo "Building the extended parser semgrep-$wrapper."
-make -C "$ext_proj" clean
-make -C "$ext_proj"
 
 # Copy the files that we find.
 #

--- a/lang/release
+++ b/lang/release
@@ -1,7 +1,8 @@
 #! /usr/bin/env bash
 #
 # Place the generated files into their own repo, to be used by an external
-# repo as a submodule.
+# repo as a submodule. Rebuilds the extended semgrep-<lang> grammar first
+# (same prerequisite as test-lang) so gen-c has grammar.json to import.
 #
 set -eu -o pipefail
 
@@ -9,9 +10,10 @@ prog_name=$(basename "$0")
 
 usage() {
   cat <<EOF
-** This may be done only after running 'test-lang'. **
-
 Publish generated code to an external repository for a specific language.
+
+Builds the extended semgrep-LANG grammar (prep + tree-sitter generate) so
+gen-c can import grammar.json, then publishes ocaml-src to semgrep-LANG.
 
 Sublanguages defined in the same tree-sitter-LANG project are considered
 different at this stage, e.g. 'tree-sitter-typescript' provides grammars
@@ -222,6 +224,22 @@ if [[ "$make_new" != true ]]; then
 else
   branch="${branch_arg:-main}"
 fi
+
+# gen-c needs grammar.json from the extended grammar; build it first (as
+# test-lang does). Dialects share a wrapper project (tsx → semgrep-typescript).
+case "$lang" in
+  typescript|tsx) wrapper=typescript ;;
+  php|php-only) wrapper=php ;;
+  apex) wrapper=sfapex ;;
+  *) wrapper=$lang ;;
+esac
+ext_proj="semgrep-grammars/src/semgrep-$wrapper"
+if [[ ! -d "$ext_proj" ]]; then
+  error "Missing extended grammar project $ext_proj"
+fi
+echo "Building the extended parser semgrep-$wrapper."
+make -C "$ext_proj" clean
+make -C "$ext_proj"
 
 # Copy the files that we find.
 #

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -1418,25 +1418,6 @@ def ensure_result_file(path: Path) -> None:
         path.write_text(json.dumps(load_result_row(path)) + "\n")
 
 
-def mark_result_failed(path: Path, detail: str) -> None:
-    """CI helper: set status=failed on an existing result, keep other fields.
-
-    Used by the integrate job so Slack/summary reflect a release failure
-    instead of the propose job's leftover `updated`. No-op when status is
-    already failed with a detail (release already reported a specific cause).
-    """
-    if _is_valid_result_file(path):
-        res = Result.from_file(path)
-        if res.status == STATUS_FAILED and res.detail:
-            return
-    else:
-        ensure_result_file(path)
-        res = Result.from_file(path)
-    res.status = STATUS_FAILED
-    res.detail = detail
-    path.write_text(res.to_json() + "\n")
-
-
 def summarize(results_dir: Path) -> None:
     """Render a markdown table from per-language result JSON files.
 
@@ -1491,17 +1472,6 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--ensure-result", metavar="FILE",
         help="CI fallback: rewrite FILE as a failed-status row if it's "
              "missing/empty/invalid (propose crashed before writing it).",
-    )
-    parser.add_argument(
-        "--mark-failed", metavar="FILE",
-        help="CI helper: set status=failed on FILE, preserving other fields "
-             "(integrate job: so Slack/summary don't keep propose's "
-             "`updated`). No-op if already failed with a detail.",
-    )
-    parser.add_argument(
-        "--failed-detail", metavar="TEXT", default="integrate failed",
-        help="With --mark-failed, the detail string to record "
-             "(default: 'integrate failed').",
     )
     parser.add_argument(
         "--json", action="store_true",
@@ -1607,30 +1577,22 @@ def run_release(root: Path, target: Target, dry_run: bool,
     if tag is None or branch is None:
         return _fail(f"{language}: no validated tag/branch; nothing to release.")
 
-    try:
-        # Check out the exact branch the propose job built + validated
-        # (submodule bump + any skill-adapted tests are committed there).
-        # Do NOT re-bump — that could pull different content than what
-        # test-lang actually validated. `lang/release` regenerates the
-        # OCaml sources from this tree via its own `make gen`.
-        run_quiet(["git", "fetch", "origin", branch], cwd=root)
-        run_quiet(["git", "checkout", branch], cwd=root)
-        run_quiet(
-            ["git", "submodule", "update", "--init", "--recursive", "--depth", "1",
-             "--", str(target.submodule.relative_to(root))],
-            cwd=root,
-        )
+    # Check out the exact branch the propose job built + validated
+    # (submodule bump + any skill-adapted tests are committed there).
+    # Do NOT re-bump — that could pull different content than what
+    # test-lang actually validated. `lang/release` regenerates the
+    # OCaml sources from this tree via its own `make gen`.
+    run_quiet(["git", "fetch", "origin", branch], cwd=root)
+    run_quiet(["git", "checkout", branch], cwd=root)
+    run_quiet(
+        ["git", "submodule", "update", "--init", "--recursive", "--depth", "1",
+         "--", str(target.submodule.relative_to(root))],
+        cwd=root,
+    )
 
-        rel = release_downstream(root, target.lang, branch, tag, dry_run=dry_run)
-        if rel is not None and rel.returncode != 0:
-            return _fail(f"{language}: lang/release failed.")
-    except SystemExit as e:
-        if e.code in (0, None):
-            raise
-        detail = e.code if isinstance(e.code, str) else f"SystemExit: {e.code}"
-        return _fail(detail)
-    except Exception as e:
-        return _fail(f"unexpected error: {type(e).__name__}: {e}")
+    rel = release_downstream(root, target.lang, branch, tag, dry_run=dry_run)
+    if rel is not None and rel.returncode != 0:
+        return _fail(f"{language}: lang/release failed.")
 
     log(f"{language}: released to semgrep-{wrapper} branch {branch} "
         f"(PR opened per dialect).")
@@ -1656,10 +1618,6 @@ def main() -> int:
 
     if args.ensure_result:
         ensure_result_file(Path(args.ensure_result))
-        return 0
-
-    if args.mark_failed:
-        mark_result_failed(Path(args.mark_failed), args.failed_detail)
         return 0
 
     if not args.language:

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -1286,7 +1286,7 @@ def open_downstream_pr(dialect: str, branch: str, tag: str,
         return
     existing = git_query(
         ["gh", "pr", "list", "--repo", repo, "--head", branch,
-         "--state", "all", "--json", "number", "-q", ".[0].number"],
+         "--state", "all", "--json", "number", "-q", ".[0].number // empty"],
         cwd=Path.cwd(),
     ).stdout.strip()
     if existing:
@@ -1303,6 +1303,32 @@ def open_downstream_pr(dialect: str, branch: str, tag: str,
     )
 
 
+def build_extended_grammar(lang: LangAndWrapper,
+                           root: Path) -> subprocess.CompletedProcess:
+    """Build semgrep-<wrapper> so `lang/release`'s gen-c has grammar.json to import.
+
+    Same prerequisite `test-lang` builds before testing. Dialects (tsx,
+    php-only, apex) share one wrapper project, so this runs once per
+    target rather than once per dialect inside `lang/release`.
+    """
+    wrapper_dir = lang.wrapper_dir(root)
+    if not wrapper_dir.is_dir():
+        return subprocess.CompletedProcess(
+            args=["make", "-C", str(wrapper_dir)], returncode=1, stdout="",
+            stderr=f"Missing extended grammar project {wrapper_dir}\n")
+    log(f"Building the extended parser semgrep-{lang.wrapper}.")
+    r = None
+    for cmd in (["make", "clean"], ["make"]):
+        log(f"$ {' '.join(cmd)}  (in {wrapper_dir})")
+        r = subprocess.run(cmd, cwd=wrapper_dir, text=True,
+                           capture_output=True, check=False)
+        sys.stderr.write(r.stdout)
+        sys.stderr.write(r.stderr)
+        if r.returncode != 0:
+            return r
+    return r
+
+
 def release_downstream(root: Path, lang: LangAndWrapper, branch: str,
                        tag: str, *, dry_run: bool) -> subprocess.CompletedProcess:
     """Release the generated parser to each semgrep-<dialect> repo, via PR.
@@ -1314,7 +1340,9 @@ def release_downstream(root: Path, lang: LangAndWrapper, branch: str,
     the downstream repos, gated behind --release, --dry-run safe.
     """
     lang_dir = root / "lang"
-    last = None
+    last = build_extended_grammar(lang, root)
+    if last.returncode != 0:
+        return last
     for dialect in release_dialects(lang):
         cmd = ["./release", dialect, "--branch", branch]
         if dry_run:
@@ -1330,7 +1358,7 @@ def release_downstream(root: Path, lang: LangAndWrapper, branch: str,
         if last.returncode != 0:
             return last
         open_downstream_pr(dialect, branch, tag, dry_run=dry_run)
-    return last  # type: ignore[return-value]
+    return last
 
 
 ###############################################################################

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -125,10 +125,13 @@ from cursor_agent_runner import (  # noqa: E402
 
 # Result statuses, in the JSON contract emitted on stdout:
 #   updated  - submodule moved to a newer tag and test-lang passed
+#              (after integrate: release to semgrep-<lang> also succeeded)
 #   no-op    - already at the latest tag
 #   no-tags  - upstream has no parseable stable release tag
 #   exists   - a branch/PR already exists for this lang+tag
-#   failed   - bump/test-lang failed, or an unexpected crash / ug.die
+#   failed   - bump/test-lang/release failed, or an unexpected crash / ug.die
+# The integrate job overwrites the propose artifact on failure so Slack /
+# summary never keep a stale `updated` row after a release failure.
 STATUS_UPDATED = "updated"
 STATUS_NO_OP = "no-op"
 STATUS_NO_TAGS = "no-tags"
@@ -1415,6 +1418,25 @@ def ensure_result_file(path: Path) -> None:
         path.write_text(json.dumps(load_result_row(path)) + "\n")
 
 
+def mark_result_failed(path: Path, detail: str) -> None:
+    """CI helper: set status=failed on an existing result, keep other fields.
+
+    Used by the integrate job so Slack/summary reflect a release failure
+    instead of the propose job's leftover `updated`. No-op when status is
+    already failed with a detail (release already reported a specific cause).
+    """
+    if _is_valid_result_file(path):
+        res = Result.from_file(path)
+        if res.status == STATUS_FAILED and res.detail:
+            return
+    else:
+        ensure_result_file(path)
+        res = Result.from_file(path)
+    res.status = STATUS_FAILED
+    res.detail = detail
+    path.write_text(res.to_json() + "\n")
+
+
 def summarize(results_dir: Path) -> None:
     """Render a markdown table from per-language result JSON files.
 
@@ -1469,6 +1491,17 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
         "--ensure-result", metavar="FILE",
         help="CI fallback: rewrite FILE as a failed-status row if it's "
              "missing/empty/invalid (propose crashed before writing it).",
+    )
+    parser.add_argument(
+        "--mark-failed", metavar="FILE",
+        help="CI helper: set status=failed on FILE, preserving other fields "
+             "(integrate job: so Slack/summary don't keep propose's "
+             "`updated`). No-op if already failed with a detail.",
+    )
+    parser.add_argument(
+        "--failed-detail", metavar="TEXT", default="integrate failed",
+        help="With --mark-failed, the detail string to record "
+             "(default: 'integrate failed').",
     )
     parser.add_argument(
         "--json", action="store_true",
@@ -1548,6 +1581,10 @@ def run_release(root: Path, target: Target, dry_run: bool,
     test-lang validated; without it (manual runs) the tag is re-resolved
     live, and a stale branch name fails loudly on the fetch (no silent
     wrong-version release).
+
+    Always emits a Result JSON line on stdout (same contract as propose) so
+    the workflow can overwrite the propose artifact and Slack/summary see
+    release failures as `failed`, not leftover `updated`.
     """
     language, wrapper = target.lang.language, target.lang.wrapper
     if result_file:
@@ -1557,27 +1594,50 @@ def run_release(root: Path, target: Target, dry_run: bool,
     else:
         tag = target.tag
         branch = branch_name(target.lang, tag) if tag else None
+        res = Result(language=language, new_tag=tag, branch=branch,
+                     ts_version=target.ts_version)
+
+    def _fail(detail: str) -> int:
+        res.status = STATUS_FAILED
+        res.detail = detail
+        log(detail)
+        print(res.to_json())
+        return 1
+
     if tag is None or branch is None:
-        ug.die(f"{language}: no validated tag/branch; nothing to release.")
+        return _fail(f"{language}: no validated tag/branch; nothing to release.")
 
-    # Check out the exact branch the propose job built + validated (submodule
-    # bump + any skill-adapted tests are committed there). Do NOT re-bump —
-    # that could pull different content than what test-lang actually
-    # validated. `lang/release` regenerates the OCaml sources from this tree
-    # via its own `make gen`.
-    run_quiet(["git", "fetch", "origin", branch], cwd=root)
-    run_quiet(["git", "checkout", branch], cwd=root)
-    run_quiet(["git", "submodule", "update", "--init", "--recursive", "--depth", "1",
-               "--", str(target.submodule.relative_to(root))], cwd=root)
+    try:
+        # Check out the exact branch the propose job built + validated
+        # (submodule bump + any skill-adapted tests are committed there).
+        # Do NOT re-bump — that could pull different content than what
+        # test-lang actually validated. `lang/release` regenerates the
+        # OCaml sources from this tree via its own `make gen`.
+        run_quiet(["git", "fetch", "origin", branch], cwd=root)
+        run_quiet(["git", "checkout", branch], cwd=root)
+        run_quiet(
+            ["git", "submodule", "update", "--init", "--recursive", "--depth", "1",
+             "--", str(target.submodule.relative_to(root))],
+            cwd=root,
+        )
 
-    rel = release_downstream(root, target.lang, branch, tag, dry_run=dry_run)
-    if rel is not None and rel.returncode != 0:
-        ug.die(f"{language}: lang/release failed.")
+        rel = release_downstream(root, target.lang, branch, tag, dry_run=dry_run)
+        if rel is not None and rel.returncode != 0:
+            return _fail(f"{language}: lang/release failed.")
+    except SystemExit as e:
+        if e.code in (0, None):
+            raise
+        detail = e.code if isinstance(e.code, str) else f"SystemExit: {e.code}"
+        return _fail(detail)
+    except Exception as e:
+        return _fail(f"unexpected error: {type(e).__name__}: {e}")
 
     log(f"{language}: released to semgrep-{wrapper} branch {branch} "
         f"(PR opened per dialect).")
-    print(json.dumps({"language": language, "new_tag": tag,
-                      "branch": branch, "released": not dry_run}))
+    res.status = STATUS_UPDATED
+    res.branch = branch
+    res.new_tag = tag
+    print(res.to_json())
     return 0
 
 
@@ -1596,6 +1656,10 @@ def main() -> int:
 
     if args.ensure_result:
         ensure_result_file(Path(args.ensure_result))
+        return 0
+
+    if args.mark_failed:
+        mark_result_failed(Path(args.mark_failed), args.failed_detail)
         return 0
 
     if not args.language:

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -459,7 +459,8 @@ class TestMainFailedJson(unittest.TestCase):
         import io
         from types import SimpleNamespace
         args = SimpleNamespace(
-            list_languages=False, summarize=None, ensure_result=None, language="php",
+            list_languages=False, summarize=None, ensure_result=None,
+            mark_failed=None, failed_detail="integrate failed", language="php",
             resolve_tag_only=False, release=False, open_pr=False, dry_run=False,
             language_agent=False, result=None, json=False, updatable_only=False,
         )
@@ -525,6 +526,101 @@ class TestEnsureResultFile(unittest.TestCase):
             path = Path(d) / "result-ruby.json"
             pg.ensure_result_file(path)
             self.assertEqual(json.loads(path.read_text())["language"], "ruby")
+
+
+class TestMarkResultFailed(unittest.TestCase):
+    """Integrate job helper: flip propose's leftover `updated` to `failed`."""
+
+    def test_preserves_propose_fields(self):
+        with TemporaryDirectory() as d:
+            path = Path(d) / "result-r.json"
+            path.write_text(pg.Result(
+                language="r", status=pg.STATUS_UPDATED, new_tag="v1.3.0",
+                branch="grammar-update/r/v1.3.0",
+                pr_url="https://example.com/pr/1",
+            ).to_json())
+            pg.mark_result_failed(path, "integrate failed (see job log)")
+            data = json.loads(path.read_text())
+            self.assertEqual(data["status"], pg.STATUS_FAILED)
+            self.assertEqual(data["detail"], "integrate failed (see job log)")
+            self.assertEqual(data["new_tag"], "v1.3.0")
+            self.assertEqual(data["pr_url"], "https://example.com/pr/1")
+
+    def test_noop_when_already_failed_with_detail(self):
+        with TemporaryDirectory() as d:
+            path = Path(d) / "result-r.json"
+            path.write_text(pg.Result(
+                language="r", status=pg.STATUS_FAILED,
+                detail="r: lang/release failed.", new_tag="v1.3.0",
+            ).to_json())
+            pg.mark_result_failed(path, "integrate failed (see job log)")
+            data = json.loads(path.read_text())
+            self.assertEqual(data["detail"], "r: lang/release failed.")
+
+
+class TestRunReleaseResultJson(unittest.TestCase):
+    """--release must emit the same Result JSON contract as propose."""
+
+    def _target(self, root: Path) -> pg.Target:
+        sub = root / "lang" / "semgrep-grammars" / "src" / "tree-sitter-r"
+        sub.mkdir(parents=True)
+        lang = pg.LangAndWrapper(language="r", wrapper="r")
+        return pg.Target(lang=lang, submodule=sub, tag="v1.3.0",
+                         ts_version="0.26.3")
+
+    def test_success_emits_updated_result(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            target = self._target(root)
+            result_path = root / "result-r.json"
+            result_path.write_text(pg.Result(
+                language="r", status=pg.STATUS_UPDATED, new_tag="v1.3.0",
+                branch="grammar-update/r/v1.3.0",
+                pr_url="https://example.com/pr/1",
+            ).to_json())
+            buf = io.StringIO()
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(unittest.mock.patch.object(
+                    pg, "run_quiet", return_value=None))
+                stack.enter_context(unittest.mock.patch.object(
+                    pg, "release_downstream",
+                    return_value=unittest.mock.Mock(returncode=0)))
+                stack.enter_context(contextlib.redirect_stdout(buf))
+                stack.enter_context(contextlib.redirect_stderr(io.StringIO()))
+                rc = pg.run_release(root, target, dry_run=False,
+                                    result_file=str(result_path))
+            data = json.loads(buf.getvalue())
+        self.assertEqual(rc, 0)
+        self.assertEqual(data["status"], pg.STATUS_UPDATED)
+        self.assertEqual(data["new_tag"], "v1.3.0")
+        self.assertEqual(data["pr_url"], "https://example.com/pr/1")
+
+    def test_failure_emits_failed_result_preserving_fields(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            target = self._target(root)
+            result_path = root / "result-r.json"
+            result_path.write_text(pg.Result(
+                language="r", status=pg.STATUS_UPDATED, new_tag="v1.3.0",
+                branch="grammar-update/r/v1.3.0",
+                pr_url="https://example.com/pr/1",
+            ).to_json())
+            buf = io.StringIO()
+            with contextlib.ExitStack() as stack:
+                stack.enter_context(unittest.mock.patch.object(
+                    pg, "run_quiet", return_value=None))
+                stack.enter_context(unittest.mock.patch.object(
+                    pg, "release_downstream",
+                    return_value=unittest.mock.Mock(returncode=1)))
+                stack.enter_context(contextlib.redirect_stdout(buf))
+                stack.enter_context(contextlib.redirect_stderr(io.StringIO()))
+                rc = pg.run_release(root, target, dry_run=False,
+                                    result_file=str(result_path))
+            data = json.loads(buf.getvalue())
+        self.assertEqual(rc, 1)
+        self.assertEqual(data["status"], pg.STATUS_FAILED)
+        self.assertIn("lang/release failed", data["detail"])
+        self.assertEqual(data["pr_url"], "https://example.com/pr/1")
 
 
 ###############################################################################

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -459,8 +459,7 @@ class TestMainFailedJson(unittest.TestCase):
         import io
         from types import SimpleNamespace
         args = SimpleNamespace(
-            list_languages=False, summarize=None, ensure_result=None,
-            mark_failed=None, failed_detail="integrate failed", language="php",
+            list_languages=False, summarize=None, ensure_result=None, language="php",
             resolve_tag_only=False, release=False, open_pr=False, dry_run=False,
             language_agent=False, result=None, json=False, updatable_only=False,
         )
@@ -528,77 +527,18 @@ class TestEnsureResultFile(unittest.TestCase):
             self.assertEqual(json.loads(path.read_text())["language"], "ruby")
 
 
-class TestMarkResultFailed(unittest.TestCase):
-    """Integrate job helper: flip propose's leftover `updated` to `failed`."""
-
-    def test_preserves_propose_fields(self):
-        with TemporaryDirectory() as d:
-            path = Path(d) / "result-r.json"
-            path.write_text(pg.Result(
-                language="r", status=pg.STATUS_UPDATED, new_tag="v1.3.0",
-                branch="grammar-update/r/v1.3.0",
-                pr_url="https://example.com/pr/1",
-            ).to_json())
-            pg.mark_result_failed(path, "integrate failed (see job log)")
-            data = json.loads(path.read_text())
-            self.assertEqual(data["status"], pg.STATUS_FAILED)
-            self.assertEqual(data["detail"], "integrate failed (see job log)")
-            self.assertEqual(data["new_tag"], "v1.3.0")
-            self.assertEqual(data["pr_url"], "https://example.com/pr/1")
-
-    def test_noop_when_already_failed_with_detail(self):
-        with TemporaryDirectory() as d:
-            path = Path(d) / "result-r.json"
-            path.write_text(pg.Result(
-                language="r", status=pg.STATUS_FAILED,
-                detail="r: lang/release failed.", new_tag="v1.3.0",
-            ).to_json())
-            pg.mark_result_failed(path, "integrate failed (see job log)")
-            data = json.loads(path.read_text())
-            self.assertEqual(data["detail"], "r: lang/release failed.")
-
-
 class TestRunReleaseResultJson(unittest.TestCase):
     """--release must emit the same Result JSON contract as propose."""
-
-    def _target(self, root: Path) -> pg.Target:
-        sub = root / "lang" / "semgrep-grammars" / "src" / "tree-sitter-r"
-        sub.mkdir(parents=True)
-        lang = pg.LangAndWrapper(language="r", wrapper="r")
-        return pg.Target(lang=lang, submodule=sub, tag="v1.3.0",
-                         ts_version="0.26.3")
-
-    def test_success_emits_updated_result(self):
-        with TemporaryDirectory() as d:
-            root = Path(d)
-            target = self._target(root)
-            result_path = root / "result-r.json"
-            result_path.write_text(pg.Result(
-                language="r", status=pg.STATUS_UPDATED, new_tag="v1.3.0",
-                branch="grammar-update/r/v1.3.0",
-                pr_url="https://example.com/pr/1",
-            ).to_json())
-            buf = io.StringIO()
-            with contextlib.ExitStack() as stack:
-                stack.enter_context(unittest.mock.patch.object(
-                    pg, "run_quiet", return_value=None))
-                stack.enter_context(unittest.mock.patch.object(
-                    pg, "release_downstream",
-                    return_value=unittest.mock.Mock(returncode=0)))
-                stack.enter_context(contextlib.redirect_stdout(buf))
-                stack.enter_context(contextlib.redirect_stderr(io.StringIO()))
-                rc = pg.run_release(root, target, dry_run=False,
-                                    result_file=str(result_path))
-            data = json.loads(buf.getvalue())
-        self.assertEqual(rc, 0)
-        self.assertEqual(data["status"], pg.STATUS_UPDATED)
-        self.assertEqual(data["new_tag"], "v1.3.0")
-        self.assertEqual(data["pr_url"], "https://example.com/pr/1")
 
     def test_failure_emits_failed_result_preserving_fields(self):
         with TemporaryDirectory() as d:
             root = Path(d)
-            target = self._target(root)
+            sub = root / "lang" / "semgrep-grammars" / "src" / "tree-sitter-r"
+            sub.mkdir(parents=True)
+            target = pg.Target(
+                lang=pg.LangAndWrapper(language="r", wrapper="r"),
+                submodule=sub, tag="v1.3.0", ts_version="0.26.3",
+            )
             result_path = root / "result-r.json"
             result_path.write_text(pg.Result(
                 language="r", status=pg.STATUS_UPDATED, new_tag="v1.3.0",

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -25,6 +25,7 @@ from __future__ import annotations
 import contextlib
 import io
 import json
+import subprocess
 import sys
 import unittest
 import unittest.mock
@@ -265,6 +266,84 @@ class TestReleaseDialects(unittest.TestCase):
             self.assertEqual(
                 pg.release_dialects(pg.LangAndWrapper("php", "php")), ["php"]
             )
+
+
+class TestOpenDownstreamPr(unittest.TestCase):
+    """`.[0].number` alone is the string "null" (truthy) on an empty `gh pr
+    list` array — without `// empty`, every release looks like a dup PR."""
+
+    def test_creates_pr_when_none_exists(self):
+        # `git_query` is real jq semantics elsewhere, so pin the actual filter
+        # string here rather than mocking it away — `.[0].number` without the
+        # `// empty` fallback prints the literal text "null" for `[]`, and
+        # that non-empty string reads as "PR exists" in Python.
+        list_calls, create_calls = [], []
+
+        def fake_git_query(cmd, cwd):
+            list_calls.append(cmd)
+            jq_expr = cmd[cmd.index("-q") + 1]
+            stdout = subprocess.run(
+                ["jq", "-r", jq_expr], input="[]", text=True,
+                capture_output=True,
+            ).stdout
+            return unittest.mock.Mock(stdout=stdout)
+
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(unittest.mock.patch.object(
+                pg, "git_query", fake_git_query))
+            stack.enter_context(unittest.mock.patch.object(
+                pg, "run_quiet", lambda cmd, cwd: create_calls.append(cmd)))
+            pg.open_downstream_pr("elixir", "grammar-update/elixir/v0.3.5",
+                                 "v0.3.5", dry_run=False)
+        self.assertEqual(len(list_calls), 1)
+        self.assertEqual(len(create_calls), 1)
+        self.assertIn("create", create_calls[0])
+
+    def test_skips_when_pr_already_exists(self):
+        with contextlib.ExitStack() as stack:
+            stack.enter_context(unittest.mock.patch.object(
+                pg, "git_query", return_value=unittest.mock.Mock(stdout="42")))
+            run_quiet_mock = stack.enter_context(
+                unittest.mock.patch.object(pg, "run_quiet"))
+            pg.open_downstream_pr("elixir", "grammar-update/elixir/v0.3.5",
+                                 "v0.3.5", dry_run=False)
+        run_quiet_mock.assert_not_called()
+
+
+class TestBuildExtendedGrammar(unittest.TestCase):
+    """`lang/release`'s gen-c needs semgrep-<wrapper> built first (LANG-579)."""
+
+    def test_missing_wrapper_dir_fails_without_running_make(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            result = pg.build_extended_grammar(
+                pg.LangAndWrapper("elixir", "elixir"), root)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Missing extended grammar project", result.stderr)
+
+    def _make_wrapper_dir(self, root: Path, *, build_ok: bool) -> None:
+        wrapper_dir = root / "lang" / "semgrep-grammars" / "src" / "semgrep-elixir"
+        wrapper_dir.mkdir(parents=True)
+        exit_code = 0 if build_ok else 1
+        # `build` first so bare `make` (no target) runs it, not `clean`.
+        (wrapper_dir / "Makefile").write_text(
+            f"build:\n\texit {exit_code}\nclean:\n\ttrue\n")
+
+    def test_runs_clean_then_build(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_wrapper_dir(root, build_ok=True)
+            result = pg.build_extended_grammar(
+                pg.LangAndWrapper("elixir", "elixir"), root)
+        self.assertEqual(result.returncode, 0)
+
+    def test_build_failure_is_reported(self):
+        with TemporaryDirectory() as d:
+            root = Path(d)
+            self._make_wrapper_dir(root, build_ok=False)
+            result = pg.build_extended_grammar(
+                pg.LangAndWrapper("elixir", "elixir"), root)
+        self.assertNotEqual(result.returncode, 0)
 
 
 class TestProposeFailurePath(unittest.TestCase):


### PR DESCRIPTION
## Summary
- Preserve propose result artifacts across checkout (`$RUNNER_TEMP`) and overwrite them on integrate failure so Slack/summary show `failed`, not leftover `updated`.
- Rebuild the extended `semgrep-<lang>` grammar in `lang/release` before `gen-c` (same as `test-lang`), fixing missing `grammar.json` on fresh integrate runs.

## Test plan
- [x] `uv run --script scripts/test_propose_grammar_update.py`
- [ ] Dispatch propose-grammar-updates for a language (e.g. elixir); confirm integrate release succeeds and Slack table matches