### PR TITLE
docs: document propose-grammar-update

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,7 +62,9 @@ $ ./test-lang kotlin
 ```
 
 For details, see [How to upgrade the grammar for a
-language](https://semgrep.dev/docs/contributing/updating-a-grammar/).
+language](https://semgrep.dev/docs/contributing/updating-a-grammar/)
+(manual) or [Propose grammar updates](doc/propose-grammar-update.md)
+(`scripts/propose-grammar-update`, automated).
 
 ### Python / ABI tests
 

--- a/doc/README.md
+++ b/doc/README.md
@@ -3,6 +3,8 @@ ocaml-tree-sitter documentation
 
 * [How to add support for a new language](http://semgrep.dev/docs/contributing/adding-a-language/)
 * [How to upgrade the grammar for a language](http://semgrep.dev/docs/contributing/updating-a-grammar/)
+  (manual walkthrough)
+* [Propose grammar updates](propose-grammar-update.md)
 * [Semgrep pattern-construct inventory for extension grammars](semgrep-constructs.md)
 * [fix-semgrep-grammar: the grammar-repair agent skill](fix-semgrep-grammar-skill.md)
 * [Releasing generated code for semgrep](release.md)

--- a/doc/propose-grammar-update.md
+++ b/doc/propose-grammar-update.md
@@ -1,0 +1,65 @@
+# Propose grammar updates (`scripts/propose-grammar-update`)
+
+Automated path for bumping an upstream `tree-sitter-<lang>` submodule to its
+latest **stable** release tag, regenerating corpus snapshots, and optionally updating the `semgrep-<lang>` grammar and opening PRs.
+
+Prefer this script (or the
+[Propose grammar updates](../.github/workflows/propose-grammar-updates.yml)
+workflow) over the manual [How to upgrade the grammar for a
+language](https://semgrep.dev/docs/contributing/updating-a-grammar/) walkthrough
+when you want a tag-pinned bump with snapshot regen and PR wiring.
+
+`scripts/update-grammar` is deprecated. New work should go through `propose-grammar-update`.
+
+## Prerequisites
+
+- Repo built/installed as in the main README (`make setup`, `make && make install`).
+- [`uv`](https://docs.astral.sh/uv/) (the script is a uv inline script).
+- For `--open-pr` / `--release`: `gh` authenticated (`GH_TOKEN` / `GITHUB_TOKEN`).
+- For `--language-agent`: `CURSOR_API_KEY` (and optionally `CURSOR_MODEL`).
+
+## Common commands
+
+All commands run as `uv run --script scripts/propose-grammar-update <args>`.
+
+| Args | What it does |
+|--|--|
+| `--list-languages [--updatable-only] [--json]` | List proposable languages |
+| `kotlin --resolve-tag-only` | Resolve the latest stable tag, no mutation |
+| `kotlin` | Bump → regenerate corpus snapshots → `test-lang` → reset tree; prints one JSON result line on stdout |
+| `kotlin --dry-run` | Full bump/test; shows the would-be PR, no push |
+| `kotlin --open-pr` | Open a PR in this repo when the bump is green |
+| `kotlin --open-pr --language-agent` | Same, dispatching the [`fix-semgrep-grammar`](fix-semgrep-grammar-skill.md) skill and re-testing on `test-lang` failure |
+| `kotlin --release --result result-kotlin.json` | Release the validated parser to `semgrep-<lang>` (after the `grammar-update/<lang>/<tag>` branch exists here); pass the propose job's result artifact so the release matches what was tested |
+| `--summarize results/` | Summarize many `result-*.json` artifacts (used by CI) |
+
+## What a successful propose does
+
+1. Picks the newest stable upstream tag this repo can build (ABI 14; respects
+   C++ scanner / declared `tree-sitter-cli` constraints).
+2. Bumps the submodule via `update-grammar --skip-release` and syncs
+   `lang/languages-*` / `lang/language-variants-*`.
+3. Regenerates corpus snapshots (`tree-sitter test --update`).
+4. Runs `./test-lang <lang>` (authoritative pass/fail).
+5. With `--open-pr`, commits on `grammar-update/<lang>/<tag>` and opens a PR
+   against `GRAMMAR_BASE_BRANCH` (default `main`).
+
+Stdout is a single JSON object (`status`: `updated`, `no-op`, `no-tags`,
+`exists`, `failed`, or dry-run). Progress goes to stderr.
+
+## CI
+
+`.github/workflows/propose-grammar-updates.yml` enumerates languages, runs
+propose per language (optional language agent), then integrates green bumps
+with `--release`. Dispatch it from the Actions UI with a single language or
+`all`.
+
+## Environment
+
+| Variable | Role |
+|--|--|
+| `GH_TOKEN` / `GITHUB_TOKEN` | `gh` for PRs / repo lookups |
+| `CURSOR_API_KEY` | Required only with `--language-agent` |
+| `CURSOR_MODEL` | Model for the language agent (default `auto`) |
+| `GRAMMAR_BASE_BRANCH` | Base branch for grammar-update PRs (default `main`) |
+| `GITHUB_ORG` | Org for `semgrep-<lang>` repos (default `semgrep`) |

--- a/doc/release.md
+++ b/doc/release.md
@@ -3,11 +3,14 @@ Releasing generated code for semgrep
 
 ⚠️ r2c admins: See note at the bottom.
 
-The process for updating a grammar and releasing the generated code in
-described in details [in this document](https://semgrep.dev/docs/contributing/updating-a-grammar/).
+The process for updating a grammar and releasing the generated code is
+described in detail [in this document](https://semgrep.dev/docs/contributing/updating-a-grammar/).
 
-Until we have an automatic process for this and for security reasons,
-please ask someone at r2c to release the code for the language.
+For an automated bump to the latest stable upstream tag, see [Propose grammar updates](propose-grammar-update.md)
+(`scripts/propose-grammar-update` and the Propose grammar updates Github workflow).
+
+Manual releases to `semgrep-<lang>` still need someone with push access
+to those repos; ask on the channels below if you do not.
 
 Contact channels:
 * your ocaml-tree-sitter pull request


### PR DESCRIPTION
Document `scripts/propose-grammar-update` as the automated grammar-update path: new `doc/propose-grammar-update.md` plus links from the README, doc index, and release notes. Marks `update-grammar` as deprecated in favor of this flow.

### Checklist

- [x] Any new parsing code was already published, integrated, and merged into Semgrep. DO NOT MERGE THIS PR BEFORE THE SEMGREP INTEGRATION WORK WAS COMPLETED.
- [x] Change has no security implications (otherwise, ping the security team)


Made with [Cursor](https://cursor.com)