### PR TITLE
Update tree-sitter-bash grammar to v0.25.1

### DIFF
--- a/lang/language-variants-0.22.6
+++ b/lang/language-variants-0.22.6
@@ -1,4 +1,3 @@
-bash
 c
 c-sharp
 c-sharp-pro

--- a/lang/language-variants-0.26.3
+++ b/lang/language-variants-0.26.3
@@ -1,3 +1,4 @@
+bash
 dart
 fga
 gosu

--- a/lang/languages-0.22.6
+++ b/lang/languages-0.22.6
@@ -1,4 +1,3 @@
-bash
 c
 c-sharp
 c-sharp-pro

--- a/lang/languages-0.26.3
+++ b/lang/languages-0.26.3
@@ -1,3 +1,4 @@
+bash
 dart
 fga
 gosu

--- a/lang/semgrep-grammars/src/semgrep-bash/grammar.js
+++ b/lang/semgrep-grammars/src/semgrep-bash/grammar.js
@@ -83,8 +83,9 @@ module.exports = grammar(base_grammar, {
       $.word
     ),
 
-    // Fragile. Copy of the original with $.word -> $._extended_word
-    function_definition: $ => seq(
+    // Fragile. Copy of upstream with $.word -> $._extended_word on
+    // `function` names so metavariables work there.
+    function_definition: $ => prec.right(seq(
       choice(
         seq(
           'function',
@@ -101,9 +102,11 @@ module.exports = grammar(base_grammar, {
         choice(
           $.compound_statement,
           $.subshell,
-          $.test_command)
-      )
-    ),
+          $.test_command,
+          $.if_statement)
+      ),
+      field('redirect', optional($._redirect)),
+    )),
 
     semgrep_metavariable: $ => /\$[A-Z_][A-Z_0-9]*/,
     semgrep_metavar_eq: $ => /\$[A-Z_][A-Z_0-9]*=/,

--- a/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
@@ -9,9 +9,17 @@ cat ...
 ---
 
 (program
-  (command (command_name (word)))
-  (command (command_name (word)) (word))
-  (command (command_name (word)) (word)))
+  (command
+    (command_name
+      (word)))
+  (command
+    (command_name
+      (word))
+    (word))
+  (command
+    (command_name
+      (word))
+    (word)))
 
 ======================================================================
 Metavariables
@@ -24,9 +32,14 @@ $FOO
 
 (program
   (command
-    (command_name (word))
-    (simple_expansion (variable_name)))
-  (command (command_name (simple_expansion (variable_name)))))
+    (command_name
+      (word))
+    (simple_expansion
+      (variable_name)))
+  (command
+    (command_name
+      (simple_expansion
+        (variable_name)))))
 
 ======================================================================
 Simple expansion
@@ -48,7 +61,8 @@ $$A
     (command_name
       (string
         (simple_expansion
-          (special_variable_name))))))
+          (special_variable_name))
+        (string_content)))))
 
 ======================================================================
 Concatenation
@@ -79,11 +93,21 @@ ${BAR}
 ---
 
 (program
-  (command (command_name (word)) (string (expansion (variable_name))))
   (command
-    (command_name (word))
-    (expansion (variable_name)))
-  (command (command_name (expansion (variable_name)))))
+    (command_name
+      (word))
+    (string
+      (expansion
+        (variable_name))))
+  (command
+    (command_name
+      (word))
+    (expansion
+      (variable_name)))
+  (command
+    (command_name
+      (expansion
+        (variable_name)))))
 
 ======================================================================
 Metavariable matching a variable
@@ -96,13 +120,16 @@ echo ${$X#/}
 
 (program
   (command
-    (command_name (word))
-    (expansion (semgrep_metavariable)))
+    (command_name
+      (word))
+    (expansion
+      (semgrep_metavariable)))
   (command
-    (command_name (word))
+    (command_name
+      (word))
     (expansion
       (semgrep_metavariable)
-      (word))))
+      (regex))))
 
 ======================================================================
 Ellipsis in unquoted concatenation
@@ -141,10 +168,12 @@ Ellipsis in quoted concatenation
     (command_name
       (string
         (simple_expansion
-          (variable_name)))))
+          (variable_name))
+        (string_content))))
   (command
     (command_name
       (string
+        (string_content)
         (simple_expansion
           (variable_name))))))
 
@@ -162,9 +191,12 @@ esac
 
 (program
   (case_statement
-    (simple_expansion (variable_name))
-    (case_item (word))
-    (case_item (word))))
+    (simple_expansion
+      (variable_name))
+    (case_item
+      (word))
+    (case_item
+      (extglob_pattern))))
 
 ======================================================================
 For loop with metavariable and ellipsis
@@ -180,7 +212,10 @@ done
   (for_statement
     (semgrep_metavariable)
     (word)
-    (do_group (command (command_name (word))))))
+    (do_group
+      (command
+        (command_name
+          (word))))))
 
 ======================================================================
 Function definition
@@ -195,8 +230,10 @@ function $FOO() {
 (program
   (function_definition
     (semgrep_metavariable)
-    (compound_statement (command (command_name (word))))))
-
+    (compound_statement
+      (command
+        (command_name
+          (word))))))
 
 ======================================================================
 Metavariable in declaration
@@ -259,7 +296,7 @@ $X= 42 command
   (command
     (variable_assignment
       (semgrep_metavar_eq)
-      (word))
+      (number))
     (variable_assignment
       (variable_name)
       (word))
@@ -270,7 +307,7 @@ $X= 42 command
     (variable_assignment
       (semgrep_metavar_eq))
     (command_name
-      (word))
+      (number))
     (word)))
 
 ======================================================================
@@ -281,7 +318,10 @@ declare -a $ARR
 
 ---
 
-(program (declaration_command (word) (semgrep_metavariable)))
+(program
+  (declaration_command
+    (word)
+    (semgrep_metavariable)))
 
 ======================================================================
 Deep expressions
@@ -344,5 +384,7 @@ $...ARGS and more
   (command
     (command_name
       (string
+        (string_content)
         (simple_expansion
-          (semgrep_named_ellipsis))))))
+          (semgrep_named_ellipsis))
+        (string_content)))))


### PR DESCRIPTION
Automated grammar update for **bash**.

- Upstream: https://github.com/tree-sitter/tree-sitter-bash.git
- `30d369ba45971a40160de34631ceea05358c9a48` → `a06c2e4415e9bc0346c6b86d401879ffb44058f7` (**v0.25.1**)
- tree-sitter version: `0.26.3`
- Compare: https://github.com/tree-sitter/tree-sitter-bash/compare/30d369ba45971a40160de34631ceea05358c9a48...v0.25.1

Corpus snapshots were auto-regenerated. **Please review** the parse-tree changes below — especially any `:error` (error-recovery) cases, which `tree-sitter test --update` does not touch automatically.

> ⚠️ **An agent adapted existing tests** for this bump (test-lang failed on the raw bump, typically a mechanical upstream CST rename). Scrutinize the test changes in the diff.

<details><summary>Corpus snapshot diff</summary>

```diff
diff --git a/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt b/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
index 8a99069..e2a1159 100644
--- a/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
+++ b/lang/semgrep-grammars/src/semgrep-bash/test/corpus/semgrep.txt
@@ -9,9 +9,17 @@ cat ...
 ---
 
 (program
-  (command (command_name (word)))
-  (command (command_name (word)) (word))
-  (command (command_name (word)) (word)))
+  (command
+    (command_name
+      (word)))
+  (command
+    (command_name
+      (word))
+    (word))
+  (command
+    (command_name
+      (word))
+    (word)))
 
 ======================================================================
 Metavariables
@@ -24,9 +32,14 @@ $FOO
 
 (program
   (command
-    (command_name (word))
-    (simple_expansion (variable_name)))
-  (command (command_name (simple_expansion (variable_name)))))
+    (command_name
+      (word))
+    (simple_expansion
+      (variable_name)))
+  (command
+    (command_name
+      (simple_expansion
+        (variable_name)))))
 
 ======================================================================
 Simple expansion
@@ -48,7 +61,8 @@ $$A
     (command_name
       (string
         (simple_expansion
-          (special_variable_name))))))
+          (special_variable_name))
+        (string_content)))))
 
 ======================================================================
 Concatenation
@@ -79,11 +93,21 @@ ${BAR}
 ---
 
 (program
-  (command (command_name (word)) (string (expansion (variable_name))))
   (command
-    (command_name (word))
-    (expansion (variable_name)))
-  (command (command_name (expansion (variable_name)))))
+    (command_name
+      (word))
+    (string
+      (expansion
+        (variable_name))))
+  (command
+    (command_name
+      (word))
+    (expansion
+      (variable_name)))
+  (command
+    (command_name
+      (expansion
+        (variable_name)))))
 
 ======================================================================
 Metavariable matching a variable
@@ -96,13 +120,16 @@ echo ${$X#/}
 
 (program
   (command
-    (command_name (word))
-    (expansion (semgrep_metavariable)))
+    (command_name
+      (word))
+    (expansion
+      (semgrep_metavariable)))
   (command
-    (command_name (word))
+    (command_name
+      (word))
     (expansion
       (semgrep_metavariable)
-      (word))))
+      (regex))))
 
 ======================================================================
 Ellipsis in unquoted concatenation
@@ -141,10 +168,12 @@ Ellipsis in quoted concatenation
     (command_name
       (string
         (simple_expansion
-          (variable_name)))))
+          (variable_name))
+        (string_content))))
   (command
     (command_name
       (string
+        (string_content)
         (simple_expansion
           (variable_name))))))
 
@@ -162,9 +191,12 @@ esac
 
 (program
   (case_statement
-    (simple_expansion (variable_name))
-    (case_item (word))
-    (case_item (word))))
+    (simple_expansion
+      (variable_name))
+    (case_item
+      (word))
+    (case_item
+      (extglob_pattern))))
 
 ======================================================================
 For loop with metavariable and ellipsis
@@ -180,7 +212,10 @@ done
   (for_statement
     (semgrep_metavariable)
     (word)
-    (do_group (command (command_name (word))))))
+    (do_group
+      (command
+        (command_name
+          (word))))))
 
 ======================================================================
 Function definition
@@ -195,8 +230,10 @@ function $FOO() {
 (program
   (function_definition
     (semgrep_metavariable)
-    (compound_statement (command (command_name (word))))))
-
+    (compound_statement
+      (command
+        (command_name
+          (word))))))
 
 ======================================================================
 Metavariable in declaration
@@ -259,7 +296,7 @@ $X= 42 command
   (command
     (variable_assignment
       (semgrep_metavar_eq)
-      (word))
+      (number))
     (variable_assignment
       (variable_name)
       (word))
@@ -270,7 +307,7 @@ $X= 42 command
     (variable_assignment
       (semgrep_metavar_eq))
     (command_name
-      (word))
+      (number))
     (word)))
 
 ======================================================================
@@ -281,7 +318,10 @@ declare -a $ARR
 
 ---
 
-(program (declaration_command (word) (semgrep_metavariable)))
+(program
+  (declaration_command
+    (word)
+    (semgrep_metavariable)))
 
 ======================================================================
 Deep expressions
@@ -344,5 +384,7 @@ $...ARGS and more
   (command
     (command_name
       (string
+        (string_content)
         (simple_expansion
-          (semgrep_named_ellipsis))))))
+          (semgrep_named_ellipsis))
+        (string_content)))))
```
</details>

<details><summary>test-lang output (tail)</summary>

```
Removing grammar-rev.js
Removing grammar-rev.js.orig
Removing grammar.js
Removing ocaml-src/
Removing parse
Removing parse-bash
Removing src/
Removing test.out/
/Library/Developer/CommandLineTools/usr/bin/make gen
/Library/Developer/CommandLineTools/usr/bin/make gen-c
if [ ! -e src/parser.c ] \
          || [ ! -e "../semgrep-grammars/lang/bash/src/grammar.json" ] \
          || [ "../semgrep-grammars/lang/bash/src/grammar.json" -nt src/parser.c ]; then \
	  /private/tmp/ots-bash-propose/scripts/ocaml-tree-sitter-gen-c; \
	else \
	  echo "src/parser.c for bash is up to date."; \
	fi
bash: Importing initial 'grammar.json'.
bash: Simplifying 'grammar.json' for ocaml-tree-sitter.
bash: Recovering informational JS grammars from JSON.
bash: Generating definitive 'parser.c'.
/Library/Developer/CommandLineTools/usr/bin/make gen-ocaml
/private/tmp/ots-bash-propose/scripts/ocaml-tree-sitter-gen-ocaml --lang bash 
/Library/Developer/CommandLineTools/usr/bin/make build-ocaml
/private/tmp/ots-bash-propose/scripts/build-ocaml
ln -sf ocaml-src/_build/install/default/bin/parse-bash
ln -sf parse-bash parse
/Library/Developer/CommandLineTools/usr/bin/make parse-examples
/private/tmp/ots-bash-propose/scripts/parse-examples ./parse-bash bash
PASS: test/ok/hello.bash
PASS: test/ok/semgrep.bash

expected results: 2 (pass: 2, xfail: 0)
unexpected results: 0 (fail: 0, xpass: 0)
if [ -f 'check-test-output' ]; then ./check-test-output; fi
bash: Checking for undesirable Blank nodes.
bash: OK
[33mWarning:[0m unnecessary conflicts:
  `heredoc_command`
ld: warning: ignoring duplicate libraries: '-ltree-sitter'
```
</details>

🤖 Generated with [Claude Code](https://claude.com/claude-code)