### PR TITLE
ci: cut the per-job setup cost of the language matrix

### DIFF
--- a/.github/actions/build-core/action.yml
+++ b/.github/actions/build-core/action.yml
@@ -10,8 +10,12 @@ runs:
     - name: Rewrite SSH submodule URLs to HTTPS
       shell: bash
       run: git config --global url."https://github.com/".insteadOf "git@github.com:"
-    # --jobs: ~50 grammar submodules, cloned sequentially by default.
-    - run: git submodule update --init --recursive --depth 1 --jobs 8
+    # --jobs: ~50 grammar submodules, cloned sequentially by default. Not
+    # --recursive: the only nested submodules are tree-sitter-bash's copy of
+    # bash-it (plus its four bats test libraries) and two spare checkouts of
+    # tree-sitter itself under tree-sitter-dart/ and tree-sitter-hcl/fuzz/.
+    # Nothing under lang/, core/scripts or any prep script reads them.
+    - run: git submodule update --init --depth 1 --jobs 8
       shell: bash
     - run: ./core/scripts/setup-node
       shell: bash


### PR DESCRIPTION
Cuts the per-job setup cost of the language matrix. Measured, not estimated.

## The problem

On `test-lang lua` (run 30511904902, warm caches) `build-core` took 187s while the actual `test-lang` work took **5s**. The job is ~97% setup, and the matrix pays it 47 times:

| phase | time | share |
|---|---|---|
| `make setup` (opam deps) | 120s | 64% |
| `git submodule update` | 53s | 28% |
| `setup-node` | 7s | 4% |
| caches + provision | 3s | 2% |

## Changes

- **Cache the opam switch.** `setup-ocaml` v3 uses a *workspace-local* switch, so the 42 dependency packages install into `./_opam`, not the opam root. Both paths are cached; `_opam/.opam-switch/build` is excluded since opam does not need it post-install and it dominates the size. Keyed on `core/*.opam` (the dependency set) rather than the core tree SHA, so editing `core/` does not invalidate it.
- **Drop `--recursive` from the submodule init.** The only nested submodules are `tree-sitter-bash`'s copy of `bash-it` plus its four bats test libraries, and two spare checkouts of tree-sitter itself under `tree-sitter-dart/` and `tree-sitter-hcl/fuzz/`. Nothing under `lang/`, `core/scripts` or any `prep` script reads them; the 47 top-level grammar submodules still init.

## Measured outcome

`build-core` duration across all successful matrix jobs:

| variant | median | max | total runner time |
|---|---|---|---|
| baseline | 189s | 221s | ~150 min |
| caching `~/.opam` only | 191s | 275s | 153 min |
| **+ `./_opam`** | **85s** | 216s | **80 min** |

Median setup **-55%**, roughly **70 min of runner time saved per run**. The remaining `max` outliers are the first-wave jobs, which miss the cache and pay the save. Wall clock is unchanged (~22 min) because the matrix is bound by `max-parallel: 8`, not by per-job time.

All 47 languages green: run 30557467211.

## Note on `semgrep/setup-ocaml`

Review feedback on #646 correctly identified that our fork caches deps + the switch, and that diagnosis is what found the bug above. Not switching to it here: the `save-opam-post-run` input that implements this is only on the fork's `master`, not in any release (checked v3.2.18..v3.4.3), and that master is 23 commits behind the `ocaml/setup-ocaml` v3.6.1 this workflow pins. **Once a fork release carries that input, this entire cache block collapses to `save-opam-post-run: true`** and should be replaced.