### PR TITLE
feat: promote XPASS examples in fix-semgrep-grammar

### DIFF
--- a/.agents/skills/fix-semgrep-grammar/SKILL.md
+++ b/.agents/skills/fix-semgrep-grammar/SKILL.md
@@ -46,10 +46,21 @@ extension grammar and its tests.**
    using the sublanguage set from Inputs (`--ignored` matters: plain status
    misses ignored files). Every `test-lang` iteration runs `git clean -dfX`
    in each of these directories — force-deleting all git-ignored files, no
-   confirmation. That's normally regenerable build output, but don't assume:
-   if the status reports anything, **stop, list what would be deleted (noting
-   which files look machine-generated), and ask the user to confirm.** A
-   clean tree needs no confirmation.
+   confirmation.
+
+   Classify the porcelain lines:
+   - **Only `!!` (ignored) regenerable build/test output** — e.g. `src/`,
+     `ocaml-src/`, `test.out/`, `parse`, `parse-<lang>`, `grammar.js` /
+     `grammar-rev.js*` under `lang/<sublang>/`, `test.log`, corpus build
+     trees under `semgrep-<lang>/` — **proceed without asking.** A prior
+     `test-lang` (or the outer propose-grammar-update pipeline) always
+     leaves these; blocking on them makes unattended runs impossible.
+   - **Any non-ignored dirty/untracked path** (modified tracked files,
+     `??` sources, or ignored paths that look like real user data) —
+     **stop**, list what would be deleted, and ask the user to confirm.
+     If no one can answer (unattended / CI), exit `CANNOT_PROCEED` with
+     that list as the blocker.
+   - **Clean tree** — no confirmation needed.
 
 2. **Ensure the toolchain** (from the repo root). Pinned tree-sitter versions
    live side by side in `core/tree-sitter-<version>/`:
@@ -121,6 +132,7 @@ extension grammar and its tests.**
    | `tree-sitter generate` errors | grammar.js references a rule upstream renamed/removed, or the overrides create an unresolved conflict (the error names the rule) |
    | corpus test diff (expected vs actual S-expr) | expected tree ≠ actual — either a legitimate upstream change or a regression from your own earlier edit; step 7 decides which |
    | example in `test.out/fail.list` — entries are paths relative to `lang/<sublang>/test/ok/`; each CST dump is at `test.out/ok/<entry>.cst` (look for `!ERROR!`/`ERROR`) | a real source file no longer parses |
+   | example in `test.out/xpass.list` — entries are paths relative to `lang/<sublang>/test/xfail/`; each CST dump is at `test.out/xfail/<entry>.cst` | an expected-fail example now parses (XPASS) — an improvement; promote it to `test/ok/` |
    | Blank-node warning not in the baseline | a node your edit introduced or exposed produces no tokens — give it a named rule |
    | tree-sitter version/ABI errors (grammar needs a newer tree-sitter than the pin, ABI mismatch) | the `lang/languages-*` pin is stale, not a grammar bug — out of scope: `CANNOT_PROCEED`, reporting the version-list change needed |
 
@@ -163,6 +175,11 @@ extension grammar and its tests.**
   — **never** the `inherited` symlink (it points at the upstream corpus). If no
   semgrep-owned file exists yet, create `test/corpus/semgrep.txt`; match the
   inherited corpus's S-expression style (e.g. no field names).
+- `lang/<sublang>/test/{ok,xfail}/**` — **only** to promote XPASS examples:
+  `git mv` each `test/xfail/<path>` listed in `test.out/xpass.list` to
+  `test/ok/<path>` (same relative path; create parent dirs under `ok/` as
+  needed). Do not edit those files' contents; do not move anything the other
+  way.
 
 **Coverage invariant: every rule override you add or change must be exercised
 by at least one semgrep-owned corpus case, added or extended in the same
@@ -178,13 +195,15 @@ the `lang/languages-*` / `language-variants-*` version lists or the submodule
 pointer; anything in the CST→AST / OCaml codegen or the `semgrep` proprietary
 repo; the `inherited` corpus symlink.
 
-**Never weaken semgrep semantics or tests to go green.** Never delete, skip,
-or relocate a test (e.g. into `test/xfail/`); never delete a semgrep
-construct; never rewrite an expected corpus tree just to silence a failure —
-expected trees change only to reflect a *legitimate* upstream structural
-change. A case you cannot make pass with a legitimate grammar change is
-`CANNOT_PROCEED` (see Exit) — unless upstream deliberately dropped the syntax,
-in which case ask the user first (see the playbook's last entry).
+**Never weaken semgrep semantics or tests to go green.** Never delete or skip
+a test; never move a test *into* `test/xfail/` (demoting expectations); never
+delete a semgrep construct; never rewrite an expected corpus tree just to
+silence a failure — expected trees change only to reflect a *legitimate*
+upstream structural change. **Promoting** an XPASS from `test/xfail/` to
+`test/ok/` is required (it tightens expectations) — see the playbook. A case
+you cannot make pass with a legitimate grammar change is `CANNOT_PROCEED`
+(see Exit) — unless upstream deliberately dropped the syntax, in which case
+ask the user first (see the playbook's last entry).
 
 ## Fix playbook
 
@@ -226,6 +245,12 @@ Common shapes when an upstream bump breaks the extension:
   like `common/define-grammar.js`) → update the extension's
   `require(...)`/wrapping to the new entry point; the rule overrides themselves
   may need no change.
+- **XPASS** (`test.out/xpass.list`) — an example under `test/xfail/` now
+  parses. That is an improvement (from the bump or from your fix). For each
+  listed path, `git mv lang/<sublang>/test/xfail/<path>` →
+  `lang/<sublang>/test/ok/<path>` (preserve the relative path). Do not edit
+  the file. Do **not** leave it in `xfail` to keep the run green — an XPASS
+  left behind is still an unexpected result and fails `parse-examples`.
 - **Upstream deliberately dropped syntax**, so a `test/ok` example or corpus
   case is legitimately no longer parseable → do **not** move it to `xfail`,
   delete it, or rewrite it on your own: **warn the user, state exactly what

--- a/doc/fix-semgrep-grammar-skill.md
+++ b/doc/fix-semgrep-grammar-skill.md
@@ -12,10 +12,13 @@ until `test-lang <lang>` passes.
 
 ## Where it operates
 
-It edits only `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js` and the
-semgrep-owned corpus files `.../test/corpus/*.txt`. It never touches the
-upstream submodule (including `scanner.c`), the `lang/languages-*` version
-pins, or the CST→AST / OCaml codegen, and it never commits or opens PRs.
+It edits only `lang/semgrep-grammars/src/semgrep-<lang>/grammar.js`, the
+semgrep-owned corpus files `.../test/corpus/*.txt`, and — when
+`parse-examples` reports XPASS — promoting those examples from
+`lang/<sublang>/test/xfail/` to `test/ok/` (an improvement: expected-fail
+tests that now pass). It never touches the upstream submodule (including
+`scanner.c`), the `lang/languages-*` version pins, or the CST→AST / OCaml
+codegen, and it never commits or opens PRs.
 
 ## Running it by hand
 
@@ -23,9 +26,11 @@ Give an agent the language and the skill:
 
     Use fix-semgrep-grammar to make test-lang javascript pass.
 
-Optionally add a tighter cap: `... pass, with max-iterations 5.` The skill
-asks for confirmation before letting `test-lang` run `git clean -dfX` over a
-dirty tree.
+Optionally add a tighter cap: `... pass, with max-iterations 5.` In interactive
+use the skill asks for confirmation before letting `test-lang` run
+`git clean -dfX` over non-ignored dirty paths; ignored regenerable build
+artifacts alone do not require confirmation (needed for unattended
+propose-grammar-update runs).
 
 ## Exit statuses
 

--- a/scripts/propose-grammar-update
+++ b/scripts/propose-grammar-update
@@ -928,13 +928,25 @@ def language_agent_prompt(lang: LangAndWrapper, tag: str,
     after a bump; the authoritative signal remains the caller's test-lang
     re-run afterward.
     """
+    xpass_hint = ""
+    if "XPASS:" in test_log or "xpass.list" in test_log:
+        # Expected-fail examples that now parse are improvements: the skill
+        # must promote them test/xfail/ → test/ok/ (not leave them xfail).
+        xpass_hint = (
+            " Note: the log shows XPASS (expected-fail examples that now "
+            "parse) — promote each listed path from test/xfail/ to test/ok/ "
+            "per the skill; that is an allowed improvement, not a weaken.\n"
+        )
     return (
         f"Use the `fix-semgrep-grammar` skill to make `test-lang {lang.language}` "
         f"pass. Context: the tree-sitter-{lang.language} submodule was just bumped "
-        f"to {tag} and test-lang now fails. Follow the skill's edit boundaries "
-        f"and exit contract exactly; do not commit, push, or open a PR — leave "
-        f"the working tree changed for the outer pipeline. Print the skill's "
-        f"final FIX-SEMGREP-GRAMMAR status line.\n\n"
+        f"to {tag} and test-lang now fails.{xpass_hint} This is an unattended "
+        f"pipeline run: do not ask for confirmation — if git status shows only "
+        f"ignored regenerable build/test artifacts, proceed; otherwise exit "
+        f"CANNOT_PROCEED. Follow the skill's edit boundaries and exit contract "
+        f"exactly; do not commit, push, or open a PR — leave the working tree "
+        f"changed for the outer pipeline. Print the skill's final "
+        f"FIX-SEMGREP-GRAMMAR status line.\n\n"
         f"Failing test-lang output:\n{tail(test_log, 60)}"
     )
 

--- a/scripts/test_propose_grammar_update.py
+++ b/scripts/test_propose_grammar_update.py
@@ -585,6 +585,25 @@ class TestLanguageAgent(unittest.TestCase):
         self.assertIn("v0.24.2", p)
         self.assertIn("do not commit", p)
         self.assertIn("FAIL log here", p)
+        self.assertIn("unattended", p)
+        self.assertNotIn("XPASS", p)
+
+    def test_prompt_hints_xpass_promotion(self):
+        # Synthetic parse-examples XPASS log — not tied to any real language
+        # fixtures (those move to test/ok/ when promoted).
+        log = (
+            "PASS: test/ok/hello.ext\n"
+            "XPASS: test/xfail/todo/was_broken.ext\n"
+            "\nunexpected results: 1 (fail: 0, xpass: 1)\n"
+            "  - 'test.out/xpass.list': parsing was expected to fail but succeeded\n"
+        )
+        p = pg.language_agent_prompt(
+            pg.LangAndWrapper("extlang", "extlang"), "v9.9.9", log
+        )
+        self.assertIn("XPASS", p)
+        self.assertIn("test/xfail/", p)
+        self.assertIn("test/ok/", p)
+        self.assertIn("promote", p.lower())
 
     def test_base_branch_default_and_override(self):
         import os


### PR DESCRIPTION
## Summary
- Teach `fix-semgrep-grammar` to treat XPASS (`test.out/xpass.list`) as an improvement: promote `test/xfail/<path>` → `test/ok/<path>` (never demote into xfail).
- Stop asking for confirmation when `git status --ignored` shows only regenerable build/test artifacts, so unattended `propose-grammar-update` runs are not blocked after `test-lang`.
- When the failing log contains XPASS, `language_agent_prompt` explicitly tells the agent to promote those paths and to run unattended.

Motivating failure: [lua propose job](https://github.com/semgrep/ocaml-tree-sitter-semgrep/actions/runs/30642055927/job/91194297490) failed only on XPASS (`builtins.lua`, `read_only_tables.lua` now parse). Dry-run with `--language-agent` after this change promoted them and returned `status: dry-run` / `tests_adapted: true`.

Stacked on `marc-andre/migrate-semgrep-scanner-agent`.

## Test plan
- [x] `uv run scripts/test_propose_grammar_update.py TestLanguageAgent -v`
- [x] Local `propose-grammar-update lua --dry-run --language-agent` promoted XPASSes and re-test passed
- [ ] Re-dispatch propose for lua in CI and confirm the language agent promotes xfail → ok


Made with [Cursor](https://cursor.com)